### PR TITLE
Security hardening for SQL interpolation and env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ inst/doc
 *.html
 Rplots.pdf
 data-raw/nge-icon_white.png
+.Renviron
+.env

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Add `frs_check_upstream()` validation for cross-BLK network connectivity
 - Add `blue_line_key` and `stream_order_min` params to `frs_point_snap()` for targeted snapping via KNN ([#16](https://github.com/NewGraphEnvironment/fresh/issues/16), [#17](https://github.com/NewGraphEnvironment/fresh/issues/17), [#7](https://github.com/NewGraphEnvironment/fresh/issues/7), [#18](https://github.com/NewGraphEnvironment/fresh/issues/18))
 - Add stream filtering guards: exclude placeholder streams (999 wscode) and unmapped tributaries (NULL localcode) from network queries; `include_all` to bypass. Subsurface flow (edge_type 1410/1425) kept in network results (real connectivity) but excluded from KNN snap candidates ([#15](https://github.com/NewGraphEnvironment/fresh/issues/15))
+- Security hardening: quote string values in SQL, validate table/column identifiers, clear error on missing PG env vars, gitignore credential files ([#19](https://github.com/NewGraphEnvironment/fresh/issues/19))
 - Input type validation on all numeric params
 - Add subbasin query vignette with tmap v4 composition
 - Fix ref CTE to always query stream network, not target table

--- a/R/frs_db_conn.R
+++ b/R/frs_db_conn.R
@@ -28,6 +28,11 @@ frs_db_conn <- function(
     user = Sys.getenv("PG_USER_SHARE"),
     password = Sys.getenv("PG_PASS_SHARE")
 ) {
+  if (!nzchar(dbname)) stop("PG_DB_SHARE env var is not set", call. = FALSE)
+  if (!nzchar(host)) stop("PG_HOST_SHARE env var is not set", call. = FALSE)
+  if (!nzchar(port)) stop("PG_PORT_SHARE env var is not set", call. = FALSE)
+  if (!nzchar(user)) stop("PG_USER_SHARE env var is not set", call. = FALSE)
+
   DBI::dbConnect(
     RPostgres::Postgres(),
     dbname = dbname,

--- a/R/frs_fish_habitat.R
+++ b/R/frs_fish_habitat.R
@@ -38,10 +38,13 @@ frs_fish_habitat <- function(
     limit = NULL,
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   clauses <- character(0)
 
   if (!is.null(watershed_group_code)) {
-    clauses <- c(clauses, paste0("watershed_group_code = '", watershed_group_code, "'"))
+    clauses <- c(clauses, paste0("watershed_group_code = ", .frs_quote_string(watershed_group_code)))
   }
   if (!is.null(blue_line_key)) {
     clauses <- c(clauses, paste0("blue_line_key = ", as.integer(blue_line_key)))

--- a/R/frs_fish_obs.R
+++ b/R/frs_fish_obs.R
@@ -39,13 +39,16 @@ frs_fish_obs <- function(
     limit = NULL,
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   clauses <- character(0)
 
   if (!is.null(species_code)) {
-    clauses <- c(clauses, paste0("species_code = '", species_code, "'"))
+    clauses <- c(clauses, paste0("species_code = ", .frs_quote_string(species_code)))
   }
   if (!is.null(watershed_group_code)) {
-    clauses <- c(clauses, paste0("watershed_group_code = '", watershed_group_code, "'"))
+    clauses <- c(clauses, paste0("watershed_group_code = ", .frs_quote_string(watershed_group_code)))
   }
   if (!is.null(blue_line_key)) {
     clauses <- c(clauses, paste0("blue_line_key = ", as.integer(blue_line_key)))

--- a/R/frs_network.R
+++ b/R/frs_network.R
@@ -24,7 +24,8 @@
 #' @param tables A named list of table specifications. Each element can be:
 #'   - A character string (table name) — uses default columns
 #'   - A list with any of: `table`, `cols`, `wscode_col`, `localcode_col`,
-#'     `extra_where`
+#'     `extra_where` (**Warning:** `extra_where` is raw SQL — never populate
+#'     from untrusted user input.)
 #'
 #'   If `NULL` (default), queries FWA streams only.
 #' @param direction Character. `"upstream"` (default) or `"downstream"`.
@@ -177,9 +178,13 @@ frs_network_direct <- function(blue_line_key, downstream_route_measure,
                                localcode_col = NULL, extra_where = NULL,
                                direction = "upstream", include_all = FALSE,
                                ...) {
+  .frs_validate_identifier(table, "table")
   wscode_col <- if (is.null(wscode_col)) "wscode_ltree" else wscode_col
   localcode_col <- if (is.null(localcode_col)) "localcode_ltree" else localcode_col
+  .frs_validate_identifier(wscode_col, "wscode_col")
+  .frs_validate_identifier(localcode_col, "localcode_col")
   cols <- if (is.null(cols)) frs_default_cols(table) else cols
+  for (col in cols) .frs_validate_identifier(col, "column")
 
   fwa_fn <- switch(direction,
     upstream = "whse_basemapping.fwa_upstream",

--- a/R/frs_network_downstream.R
+++ b/R/frs_network_downstream.R
@@ -48,6 +48,11 @@ frs_network_downstream <- function(
     include_all = FALSE,
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  .frs_validate_identifier(wscode_col, "wscode_col")
+  .frs_validate_identifier(localcode_col, "localcode_col")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   select_cols <- paste(paste0("s.", cols), collapse = ", ")
 
   guard_sql <- ""

--- a/R/frs_network_prune.R
+++ b/R/frs_network_prune.R
@@ -12,7 +12,8 @@
 #' @param watershed_group_code Character. Restrict to a watershed group. Default
 #'   `NULL`.
 #' @param extra_where Character vector of additional SQL predicates (applied to
-#'   alias `s`). Default `NULL`.
+#'   alias `s`). Default `NULL`. **Warning:** this is raw SQL — never populate
+#'   from untrusted user input.
 #' @param include_all Logical. If `TRUE`, include placeholder streams (999
 #'   wscode) and unmapped tributaries (NULL localcode). Default `FALSE` filters
 #'   these out. Only applied when querying the FWA base table.
@@ -76,6 +77,11 @@ frs_network_prune <- function(
     localcode_col = "localcode_ltree",
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  .frs_validate_identifier(wscode_col, "wscode_col")
+  .frs_validate_identifier(localcode_col, "localcode_col")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   filters <- character(0)
 
   if (!include_all && .is_fwa_stream_table(table)) {
@@ -89,7 +95,7 @@ frs_network_prune <- function(
     filters <- c(filters, paste0("s.gradient <= ", gradient_max))
   }
   if (!is.null(watershed_group_code)) {
-    filters <- c(filters, paste0("s.watershed_group_code = '", watershed_group_code, "'"))
+    filters <- c(filters, paste0("s.watershed_group_code = ", .frs_quote_string(watershed_group_code)))
   }
   if (!is.null(extra_where)) {
     filters <- c(filters, extra_where)

--- a/R/frs_network_upstream.R
+++ b/R/frs_network_upstream.R
@@ -57,6 +57,11 @@ frs_network_upstream <- function(
     include_all = FALSE,
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  .frs_validate_identifier(wscode_col, "wscode_col")
+  .frs_validate_identifier(localcode_col, "localcode_col")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   select_cols <- paste(paste0("s.", cols), collapse = ", ")
 
   guard_sql <- ""

--- a/R/frs_stream_fetch.R
+++ b/R/frs_stream_fetch.R
@@ -57,6 +57,9 @@ frs_stream_fetch <- function(
     limit = NULL,
     ...
 ) {
+  .frs_validate_identifier(table, "table")
+  for (col in cols) .frs_validate_identifier(col, "column")
+
   extra_guards <- character(0)
   if (!include_all && .is_fwa_stream_table(table)) {
     extra_guards <- .frs_stream_guards(alias = "")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,38 @@
 # Internal helpers — not exported
 
+#' Quote a string value for safe SQL interpolation
+#'
+#' Escapes single quotes by doubling them (SQL standard) and wraps in single
+#' quotes. Prevents SQL injection for string literals without needing a DB
+#' connection.
+#'
+#' @param x Character scalar.
+#' @return Character scalar, e.g. `"'O''Brien'"`.
+#' @noRd
+.frs_quote_string <- function(x) {
+  paste0("'", gsub("'", "''", x, fixed = TRUE), "'")
+}
+
+
+#' Validate a SQL identifier (table or column name)
+#'
+#' Checks that the identifier matches a safe pattern: word characters, dots
+#' (for schema-qualified names), and underscores. Stops with an informative
+#' error if validation fails.
+#'
+#' @param x Character scalar.
+#' @param label Character. Name used in error message (e.g. `"table"`).
+#' @return `x` invisibly (called for side effect).
+#' @noRd
+.frs_validate_identifier <- function(x, label = "identifier") {
+  if (identical(x, "*")) return(invisible(x))
+  if (!grepl("^[A-Za-z_][A-Za-z0-9_.]*$", x)) {
+    stop(sprintf("%s contains invalid characters: %s", label, x), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
 #' Build a SQL WHERE clause from common filter parameters
 #'
 #' @param watershed_group_code Character or NULL.
@@ -20,7 +53,7 @@
   if (!is.null(watershed_group_code)) {
     clauses <- c(
       clauses,
-      paste0("watershed_group_code = '", watershed_group_code, "'")
+      paste0("watershed_group_code = ", .frs_quote_string(watershed_group_code))
     )
   }
 

--- a/man/frs_network.Rd
+++ b/man/frs_network.Rd
@@ -33,7 +33,8 @@ on a tributary.}
 \itemize{
 \item A character string (table name) — uses default columns
 \item A list with any of: \code{table}, \code{cols}, \code{wscode_col}, \code{localcode_col},
-\code{extra_where}
+\code{extra_where} (\strong{Warning:} \code{extra_where} is raw SQL — never populate
+from untrusted user input.)
 }
 
 If \code{NULL} (default), queries FWA streams only.}

--- a/man/frs_network_prune.Rd
+++ b/man/frs_network_prune.Rd
@@ -36,7 +36,8 @@ reference point.}
 \code{NULL}.}
 
 \item{extra_where}{Character vector of additional SQL predicates (applied to
-alias \code{s}). Default \code{NULL}.}
+alias \code{s}). Default \code{NULL}. \strong{Warning:} this is raw SQL — never populate
+from untrusted user input.}
 
 \item{include_all}{Logical. If \code{TRUE}, include placeholder streams (999
 wscode) and unmapped tributaries (NULL localcode). Default \code{FALSE} filters

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,33 @@
+# -- SQL quoting ---------------------------------------------------------------
+
+test_that(".frs_quote_string escapes single quotes", {
+  expect_equal(fresh:::.frs_quote_string("BULK"), "'BULK'")
+  expect_equal(fresh:::.frs_quote_string("O'Brien"), "'O''Brien'")
+  expect_equal(fresh:::.frs_quote_string("'; DROP TABLE --"), "'''; DROP TABLE --'")
+})
+
+# -- identifier validation ----------------------------------------------------
+
+test_that(".frs_validate_identifier accepts valid names", {
+  expect_silent(fresh:::.frs_validate_identifier("blue_line_key", "column"))
+  expect_silent(fresh:::.frs_validate_identifier("whse_basemapping.fwa_stream_networks_sp", "table"))
+  expect_silent(fresh:::.frs_validate_identifier("*", "column"))
+})
+
+test_that(".frs_validate_identifier rejects injection attempts", {
+  expect_error(fresh:::.frs_validate_identifier("'; DROP TABLE --", "table"),
+    "table contains invalid characters")
+  expect_error(fresh:::.frs_validate_identifier("col; DELETE", "column"),
+    "column contains invalid characters")
+  expect_error(fresh:::.frs_validate_identifier("1bad", "column"),
+    "column contains invalid characters")
+})
+
+# -- env var check -------------------------------------------------------------
+
+test_that("frs_db_conn stops on missing env vars", {
+  expect_error(frs_db_conn(dbname = ""), "PG_DB_SHARE")
+  expect_error(frs_db_conn(dbname = "x", host = ""), "PG_HOST_SHARE")
+  expect_error(frs_db_conn(dbname = "x", host = "x", port = ""), "PG_PORT_SHARE")
+  expect_error(frs_db_conn(dbname = "x", host = "x", port = "5432", user = ""), "PG_USER_SHARE")
+})


### PR DESCRIPTION
## Summary

- Quote all string values in SQL with single-quote escaping (prevents injection)
- Validate table and column identifiers against `^[A-Za-z_][A-Za-z0-9_.]*$`
- Clear `stop()` on missing `PG_*_SHARE` env vars instead of cryptic connection error
- Add `.Renviron` and `.env` to `.gitignore`
- Document `extra_where` as raw SQL with injection warning
- 13 new tests for security helpers

## Test plan

- [x] All 239 tests pass
- [x] SQL injection attempts stopped by quoting and identifier validation
- [x] Missing env vars produce clear error messages

Fixes #19
Relates to NewGraphEnvironment/sred-2025-2026#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
