### PR TITLE
Fix R CMD check for public release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^data-raw$
 ^dev$
 ^planning$
+^\.claude$
+^vignettes/figure$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     gq,
     knitr,
     rmarkdown,
+    mockery,
     testthat (>= 3.0.0),
     tmap (>= 4.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary

- Add `mockery` to Suggests (fixes unstated dependency WARNING)
- Add `.claude/` to `.Rbuildignore` (fixes hidden directory NOTE)
- Add `vignettes/figure/` to `.Rbuildignore` (fixes knitr leftover NOTE)

Package now passes `R CMD check` with 0 errors, 0 warnings, 0 notes.

## Test plan

- [x] `devtools::check()` clean

Relates to NewGraphEnvironment/sred-2025-2026#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
