### PR TITLE
Migrate to conn-first API for all functions

### DIFF
--- a/R/frs_db_query.R
+++ b/R/frs_db_query.R
@@ -1,11 +1,10 @@
 #' Query FWA PostgreSQL Database
 #'
-#' Connects via [frs_db_conn()], executes a SQL query, disconnects, and
-#' returns the result. Uses [sf::st_read()] so spatial columns are returned
-#' as sf geometry.
+#' Executes a SQL query on an open connection. Uses [sf::st_read()] so
+#' spatial columns are returned as sf geometry.
 #'
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #' @param query Character. SQL query string.
-#' @param ... Additional arguments passed to [frs_db_conn()].
 #'
 #' @return An `sf` data frame (if the query returns geometry) or a plain
 #'   data frame.
@@ -16,10 +15,10 @@
 #'
 #' @examples
 #' \dontrun{
-#' frs_db_query("SELECT * FROM whse_basemapping.fwa_lakes_poly LIMIT 5")
+#' conn <- frs_db_conn()
+#' frs_db_query(conn, "SELECT * FROM whse_basemapping.fwa_lakes_poly LIMIT 5")
+#' DBI::dbDisconnect(conn)
 #' }
-frs_db_query <- function(query, ...) {
-  conn <- frs_db_conn(...)
-  on.exit(DBI::dbDisconnect(conn))
+frs_db_query <- function(conn, query) {
   sf::st_read(conn, query = query)
 }

--- a/R/frs_fish_habitat.R
+++ b/R/frs_fish_habitat.R
@@ -11,7 +11,7 @@
 #' @param cols Character vector of column names to select. Default includes
 #'   the most commonly used habitat model attributes.
 #' @param limit Integer. Maximum rows to return. Default `NULL`.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of stream segments with bcfishpass habitat model
 #'   columns (barriers, access, gradient, channel width, etc.).
@@ -22,10 +22,13 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Habitat model for the Bulkley
-#' habitat <- frs_fish_habitat(watershed_group_code = "BULK", limit = 100)
+#' conn <- frs_db_conn()
+#' habitat <- frs_fish_habitat(conn, watershed_group_code = "BULK",
+#'   limit = 100)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_fish_habitat <- function(
+    conn,
     watershed_group_code = NULL,
     blue_line_key = NULL,
     table = "bcfishpass.streams_vw",
@@ -35,8 +38,7 @@ frs_fish_habitat <- function(
       "stream_order", "channel_width", "gradient", "mad_m3s",
       "watershed_group_code", "wscode", "localcode", "geom"
     ),
-    limit = NULL,
-    ...
+    limit = NULL
 ) {
   .frs_validate_identifier(table, "table")
   for (col in cols) .frs_validate_identifier(col, "column")
@@ -63,5 +65,5 @@ frs_fish_habitat <- function(
     if (!is.null(limit)) paste0(" LIMIT ", as.integer(limit))
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_fish_obs.R
+++ b/R/frs_fish_obs.R
@@ -12,7 +12,7 @@
 #' @param cols Character vector of column names to select. Default includes
 #'   the most commonly used observation attributes.
 #' @param limit Integer. Maximum rows to return. Default `NULL`.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of fish observation events.
 #'
@@ -22,10 +22,13 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Chinook observations in the Bulkley
-#' obs <- frs_fish_obs(species_code = "CH", watershed_group_code = "BULK")
+#' conn <- frs_db_conn()
+#' obs <- frs_fish_obs(conn, species_code = "CH",
+#'   watershed_group_code = "BULK")
+#' DBI::dbDisconnect(conn)
 #' }
 frs_fish_obs <- function(
+    conn,
     species_code = NULL,
     watershed_group_code = NULL,
     blue_line_key = NULL,
@@ -36,8 +39,7 @@ frs_fish_obs <- function(
       "downstream_route_measure", "watershed_group_code",
       "wscode_ltree", "localcode_ltree", "geom"
     ),
-    limit = NULL,
-    ...
+    limit = NULL
 ) {
   .frs_validate_identifier(table, "table")
   for (col in cols) .frs_validate_identifier(col, "column")
@@ -67,5 +69,5 @@ frs_fish_obs <- function(
     if (!is.null(limit)) paste0(" LIMIT ", as.integer(limit))
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_lake_fetch.R
+++ b/R/frs_lake_fetch.R
@@ -15,7 +15,7 @@
 #' @param cols Character vector of column names to select. Default includes
 #'   the most commonly used FWA lake attributes.
 #' @param limit Integer. Maximum rows to return. Default `NULL` (no limit).
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of lake polygons.
 #'
@@ -25,13 +25,14 @@
 #'
 #' @examples
 #' \dontrun{
-#' # All lakes in the Bulkley watershed group
-#' lakes <- frs_lake_fetch(watershed_group_code = "BULK")
-#'
-#' # Lakes larger than 10 ha
-#' lakes <- frs_lake_fetch(watershed_group_code = "BULK", area_ha_min = 10)
+#' conn <- frs_db_conn()
+#' lakes <- frs_lake_fetch(conn, watershed_group_code = "BULK")
+#' lakes_big <- frs_lake_fetch(conn, watershed_group_code = "BULK",
+#'   area_ha_min = 10)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_lake_fetch <- function(
+    conn,
     watershed_group_code = NULL,
     blue_line_key = NULL,
     bbox = NULL,
@@ -41,8 +42,7 @@ frs_lake_fetch <- function(
       "waterbody_poly_id", "waterbody_key", "waterbody_type", "area_ha",
       "gnis_name_1", "blue_line_key", "watershed_group_code", "geom"
     ),
-    limit = NULL,
-    ...
+    limit = NULL
 ) {
   where <- .frs_build_where(
     watershed_group_code = watershed_group_code,
@@ -60,5 +60,5 @@ frs_lake_fetch <- function(
     if (!is.null(limit)) paste0(" LIMIT ", as.integer(limit))
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_network.R
+++ b/R/frs_network.R
@@ -35,7 +35,7 @@
 #' @param clip An `sf` or `sfc` polygon to clip results to (e.g. from
 #'   [frs_watershed_at_measure()]). Default `NULL` (no clipping). Useful for
 #'   waterbody polygons that straddle watershed boundaries. See [frs_clip()].
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return A named list of `sf` data frames (or plain data frames for tables
 #'   without geometry). If only one table is queried, returns the data frame
@@ -47,24 +47,28 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
 #' blk <- 360873822
 #'
 #' # Everything upstream of a point
-#' streams <- frs_network(blk, 166030)
+#' streams <- frs_network(conn, blk, 166030)
 #'
 #' # Between two points (subbasin): upstream of Byman minus upstream of Ailport
-#' result <- frs_network(blk, 208877, upstream_measure = 233564, tables = list(
-#'   streams = "whse_basemapping.fwa_stream_networks_sp",
-#'   lakes = "whse_basemapping.fwa_lakes_poly",
-#'   crossings = "bcfishpass.crossings",
-#'   observations = list(
-#'     table = "bcfishpass.observations_vw",
-#'     wscode_col = "wscode",
-#'     localcode_col = "localcode"
-#'   )
-#' ))
+#' result <- frs_network(conn, blk, 208877, upstream_measure = 233564,
+#'   tables = list(
+#'     streams = "whse_basemapping.fwa_stream_networks_sp",
+#'     lakes = "whse_basemapping.fwa_lakes_poly",
+#'     crossings = "bcfishpass.crossings",
+#'     observations = list(
+#'       table = "bcfishpass.observations_vw",
+#'       wscode_col = "wscode",
+#'       localcode_col = "localcode"
+#'     )
+#'   ))
+#' DBI::dbDisconnect(conn)
 #' }
 frs_network <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     upstream_measure = NULL,
@@ -72,8 +76,7 @@ frs_network <- function(
     tables = NULL,
     direction = "upstream",
     include_all = FALSE,
-    clip = NULL,
-    ...
+    clip = NULL
 ) {
   if (!is.numeric(blue_line_key) || length(blue_line_key) != 1 || is.na(blue_line_key)) {
     stop("blue_line_key must be a single numeric value")
@@ -107,8 +110,8 @@ frs_network <- function(
       stop("upstream_measure must be greater than downstream_route_measure")
     }
     if (up_blk != blue_line_key) {
-      frs_check_upstream(blue_line_key, downstream_route_measure,
-                         up_blk, upstream_measure, ...)
+      frs_check_upstream(conn, blue_line_key, downstream_route_measure,
+                         up_blk, upstream_measure)
     }
   }
 
@@ -123,14 +126,14 @@ frs_network <- function(
 
   results <- lapply(tables, function(spec) {
     frs_network_one(
+      conn = conn,
       blue_line_key = blue_line_key,
       downstream_route_measure = downstream_route_measure,
       upstream_measure = upstream_measure,
       upstream_blk = up_blk,
       spec = spec,
       direction = direction,
-      include_all = include_all,
-      ...
+      include_all = include_all
     )
   })
 
@@ -147,9 +150,9 @@ frs_network <- function(
 
 
 #' @noRd
-frs_network_one <- function(blue_line_key, downstream_route_measure,
+frs_network_one <- function(conn, blue_line_key, downstream_route_measure,
                             upstream_measure = NULL, upstream_blk = NULL,
-                            spec, direction, include_all = FALSE, ...) {
+                            spec, direction, include_all = FALSE) {
   tbl <- spec$table
   cols <- spec$cols
   wscode_col <- spec$wscode_col
@@ -163,33 +166,32 @@ frs_network_one <- function(blue_line_key, downstream_route_measure,
 
   if (is_waterbody) {
     frs_network_waterbody(
-      blue_line_key, downstream_route_measure,
+      conn, blue_line_key, downstream_route_measure,
       upstream_measure = upstream_measure,
       upstream_blk = up_blk,
       table = tbl, cols = cols, direction = direction,
-      include_all = include_all, ...
+      include_all = include_all
     )
   } else {
     frs_network_direct(
-      blue_line_key, downstream_route_measure,
+      conn, blue_line_key, downstream_route_measure,
       upstream_measure = upstream_measure,
       upstream_blk = up_blk,
       table = tbl, cols = cols,
       wscode_col = wscode_col, localcode_col = localcode_col,
       extra_where = extra_where, direction = direction,
-      include_all = include_all, ...
+      include_all = include_all
     )
   }
 }
 
 
 #' @noRd
-frs_network_direct <- function(blue_line_key, downstream_route_measure,
+frs_network_direct <- function(conn, blue_line_key, downstream_route_measure,
                                upstream_measure = NULL, upstream_blk = NULL,
                                table, cols = NULL, wscode_col = NULL,
                                localcode_col = NULL, extra_where = NULL,
-                               direction = "upstream", include_all = FALSE,
-                               ...) {
+                               direction = "upstream", include_all = FALSE) {
   .frs_validate_identifier(table, "table")
   wscode_col <- if (is.null(wscode_col)) "wscode_ltree" else wscode_col
   localcode_col <- if (is.null(localcode_col)) "localcode_ltree" else localcode_col
@@ -290,15 +292,15 @@ frs_network_direct <- function(blue_line_key, downstream_route_measure,
     )
   }
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }
 
 
 #' @noRd
-frs_network_waterbody <- function(blue_line_key, downstream_route_measure,
+frs_network_waterbody <- function(conn, blue_line_key, downstream_route_measure,
                                   upstream_measure = NULL, upstream_blk = NULL,
                                   table, cols = NULL, direction = "upstream",
-                                  include_all = FALSE, ...) {
+                                  include_all = FALSE) {
   cols <- if (is.null(cols)) frs_default_cols(table) else cols
 
   fwa_fn <- switch(direction,
@@ -395,7 +397,7 @@ frs_network_waterbody <- function(blue_line_key, downstream_route_measure,
     )
   }
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }
 
 
@@ -441,7 +443,7 @@ frs_default_cols <- function(table) {
 
 
 #' @noRd
-frs_check_upstream <- function(down_blk, down_drm, up_blk, up_drm, ...) {
+frs_check_upstream <- function(conn, down_blk, down_drm, up_blk, up_drm) {
   sql <- sprintf(
     paste0(
       "WITH ref_down AS (\n",
@@ -469,7 +471,7 @@ frs_check_upstream <- function(down_blk, down_drm, up_blk, up_drm, ...) {
     as.integer(down_blk), down_drm,
     as.integer(up_blk), up_drm
   )
-  result <- frs_db_query(sql, ...)
+  result <- frs_db_query(conn, sql)
   if (nrow(result) == 0 || !isTRUE(result$is_upstream)) {
     stop("upstream point (blk ", up_blk, ") is not upstream of downstream ",
          "point (blk ", down_blk, "); points may not be on the same network")

--- a/R/frs_network_downstream.R
+++ b/R/frs_network_downstream.R
@@ -17,7 +17,7 @@
 #' @param include_all Logical. If `TRUE`, include placeholder streams (999
 #'   wscode) and unmapped tributaries (NULL localcode). Default `FALSE` filters
 #'   these out. Only applied when querying the FWA base table.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of downstream stream segments.
 #'
@@ -27,13 +27,15 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Get all streams downstream of a point
-#' downstream <- frs_network_downstream(
+#' conn <- frs_db_conn()
+#' downstream <- frs_network_downstream(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030
 #' )
+#' DBI::dbDisconnect(conn)
 #' }
 frs_network_downstream <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     table = "whse_basemapping.fwa_stream_networks_sp",
@@ -45,8 +47,7 @@ frs_network_downstream <- function(
     ),
     wscode_col = "wscode_ltree",
     localcode_col = "localcode_ltree",
-    include_all = FALSE,
-    ...
+    include_all = FALSE
 ) {
   .frs_validate_identifier(table, "table")
   .frs_validate_identifier(wscode_col, "wscode_col")
@@ -88,5 +89,5 @@ frs_network_downstream <- function(
     guard_sql
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_network_prune.R
+++ b/R/frs_network_prune.R
@@ -25,7 +25,7 @@
 #'   Default `"wscode_ltree"`. Use `"wscode"` for bcfishpass views.
 #' @param localcode_col Character. Name of the local code ltree column.
 #'   Default `"localcode_ltree"`. Use `"localcode"` for bcfishpass views.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of filtered upstream stream segments.
 #'
@@ -41,8 +41,10 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # Upstream network from FWA base table, order >= 3
-#' pruned <- frs_network_prune(
+#' pruned <- frs_network_prune(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030,
 #'   stream_order_min = 3,
@@ -51,7 +53,7 @@
 #'
 #' # Coho rearing/spawning upstream of Neexdzii Kwa confluence
 #' # NB: rearing/spawning filters drop lake/wetland segments (see @note)
-#' co_habitat <- frs_network_prune(
+#' co_habitat <- frs_network_prune(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030.4,
 #'   stream_order_min = 4,
@@ -64,8 +66,10 @@
 #'   wscode_col = "wscode",
 #'   localcode_col = "localcode"
 #' )
+#' DBI::dbDisconnect(conn)
 #' }
 frs_network_prune <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     stream_order_min = NULL,
@@ -81,8 +85,7 @@ frs_network_prune <- function(
       "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"
     ),
     wscode_col = "wscode_ltree",
-    localcode_col = "localcode_ltree",
-    ...
+    localcode_col = "localcode_ltree"
 ) {
   .frs_validate_identifier(table, "table")
   .frs_validate_identifier(wscode_col, "wscode_col")
@@ -143,5 +146,5 @@ frs_network_prune <- function(
     filter_sql
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_network_upstream.R
+++ b/R/frs_network_upstream.R
@@ -17,7 +17,7 @@
 #' @param include_all Logical. If `TRUE`, include placeholder streams (999
 #'   wscode) and unmapped tributaries (NULL localcode). Default `FALSE` filters
 #'   these out. Only applied when querying the FWA base table.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of upstream stream segments.
 #'
@@ -27,22 +27,26 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # Get all streams upstream of a point on the Bulkley
-#' upstream <- frs_network_upstream(
+#' upstream <- frs_network_upstream(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030
 #' )
 #'
 #' # Use bcfishpass coho view
-#' upstream <- frs_network_upstream(
+#' upstream <- frs_network_upstream(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030,
 #'   table = "bcfishpass.streams_co_vw",
 #'   wscode_col = "wscode",
 #'   localcode_col = "localcode"
 #' )
+#' DBI::dbDisconnect(conn)
 #' }
 frs_network_upstream <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     table = "whse_basemapping.fwa_stream_networks_sp",
@@ -54,8 +58,7 @@ frs_network_upstream <- function(
     ),
     wscode_col = "wscode_ltree",
     localcode_col = "localcode_ltree",
-    include_all = FALSE,
-    ...
+    include_all = FALSE
 ) {
   .frs_validate_identifier(table, "table")
   .frs_validate_identifier(wscode_col, "wscode_col")
@@ -97,5 +100,5 @@ frs_network_upstream <- function(
     guard_sql
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -5,8 +5,9 @@
 #' iteration with [lapply()] or `purrr::walk()` over the `frs_break()` /
 #' `frs_classify()` pipeline.
 #'
-#' @param conn A [DBI::DBIConnection-class] object. Required when reading
-#'   from a database table. Ignored when `csv` is provided.
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
+#'   Required when reading from a database table. Use `NULL` when reading
+#'   from a CSV file.
 #' @param table Character. Schema-qualified table name to read parameters from.
 #'   Default `"bcfishpass.parameters_habitat_thresholds"`.
 #' @param csv Character or `NULL`. Path to a local CSV file. When provided,

--- a/R/frs_point_locate.R
+++ b/R/frs_point_locate.R
@@ -5,7 +5,7 @@
 #'
 #' @param blue_line_key Integer. Blue line key of the stream.
 #' @param downstream_route_measure Numeric. Downstream route measure in metres.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame with a single point geometry.
 #'
@@ -15,18 +15,20 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Get the point at measure 1000 on a stream
-#' pt <- frs_point_locate(blue_line_key = 360873822, downstream_route_measure = 1000)
+#' conn <- frs_db_conn()
+#' pt <- frs_point_locate(conn, blue_line_key = 360873822,
+#'   downstream_route_measure = 1000)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_point_locate <- function(
+    conn,
     blue_line_key,
-    downstream_route_measure,
-    ...
+    downstream_route_measure
 ) {
   sql <- sprintf(
     "SELECT * FROM whse_basemapping.fwa_locatealong(%s, %s)",
     as.integer(blue_line_key),
     downstream_route_measure
   )
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_point_snap.R
+++ b/R/frs_point_snap.R
@@ -17,7 +17,7 @@
 #'   `fwa_stream_networks_sp` with measure derivation and boundary clamping.
 #' @param stream_order_min Integer. Optional. Minimum stream order for snap
 #'   candidates. Ignored when `blue_line_key` is provided. Forces KNN path.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame with columns: `linear_feature_id`, `gnis_name`,
 #'   `blue_line_key`, `downstream_route_measure`, `distance_to_stream`, and
@@ -29,24 +29,28 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # Snap to nearest stream (any)
-#' snapped <- frs_point_snap(x = -126.5, y = 54.5)
+#' snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 #'
 #' # Snap to a specific stream (Bulkley River)
-#' snapped <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+#' snapped <- frs_point_snap(conn, x = -126.5, y = 54.5,
+#'   blue_line_key = 360873822)
 #'
 #' # Snap to order 4+ streams only
-#' snapped <- frs_point_snap(x = -126.5, y = 54.5, stream_order_min = 4)
+#' snapped <- frs_point_snap(conn, x = -126.5, y = 54.5, stream_order_min = 4)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_point_snap <- function(
+    conn,
     x,
     y,
     srid = 4326L,
     tolerance = 5000,
     num_features = 1L,
     blue_line_key = NULL,
-    stream_order_min = NULL,
-    ...
+    stream_order_min = NULL
 ) {
   if (!is.numeric(x) || length(x) != 1 || is.na(x)) {
     stop("x must be a single numeric value")
@@ -78,9 +82,9 @@ frs_point_snap <- function(
 
   if (!is.null(blue_line_key) || !is.null(stream_order_min)) {
     return(frs_point_snap_knn(
-      x = x, y = y, srid = srid, tolerance = tolerance,
+      conn = conn, x = x, y = y, srid = srid, tolerance = tolerance,
       num_features = num_features, blue_line_key = blue_line_key,
-      stream_order_min = stream_order_min, ...
+      stream_order_min = stream_order_min
     ))
   }
 
@@ -92,7 +96,7 @@ frs_point_snap <- function(
     ),
     x, y, as.integer(srid), tolerance, as.integer(num_features)
   )
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }
 
 
@@ -105,8 +109,8 @@ frs_point_snap <- function(
 #'
 #' @noRd
 frs_point_snap_knn <- function(
-    x, y, srid, tolerance, num_features,
-    blue_line_key = NULL, stream_order_min = NULL, ...
+    conn, x, y, srid, tolerance, num_features,
+    blue_line_key = NULL, stream_order_min = NULL
 ) {
   # Build WHERE clauses for stream filtering (includes subsurface guard)
   where_parts <- .frs_snap_guards("s")
@@ -169,5 +173,5 @@ frs_point_snap_knn <- function(
     tolerance,
     as.integer(num_features)
   )
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_stream_fetch.R
+++ b/R/frs_stream_fetch.R
@@ -19,7 +19,7 @@
 #'   wscode) and unmapped tributaries (NULL localcode). Default `FALSE` filters
 #'   these out. Only applied when querying the FWA base table.
 #' @param limit Integer. Maximum rows to return. Default `NULL` (no limit).
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of stream segments.
 #'
@@ -29,19 +29,18 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # All streams in the Bulkley watershed group
-#' streams <- frs_stream_fetch(watershed_group_code = "BULK")
+#' streams <- frs_stream_fetch(conn, watershed_group_code = "BULK")
 #'
 #' # Streams with order >= 4
-#' streams <- frs_stream_fetch(watershed_group_code = "BULK", stream_order_min = 4)
-#'
-#' # Custom columns and table
-#' streams <- frs_stream_fetch(
-#'   watershed_group_code = "BULK",
-#'   cols = c("blue_line_key", "gnis_name", "stream_order", "geom")
-#' )
+#' streams <- frs_stream_fetch(conn, watershed_group_code = "BULK",
+#'   stream_order_min = 4)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_stream_fetch <- function(
+    conn,
     watershed_group_code = NULL,
     blue_line_key = NULL,
     bbox = NULL,
@@ -54,8 +53,7 @@ frs_stream_fetch <- function(
       "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"
     ),
     include_all = FALSE,
-    limit = NULL,
-    ...
+    limit = NULL
 ) {
   .frs_validate_identifier(table, "table")
   for (col in cols) .frs_validate_identifier(col, "column")
@@ -82,5 +80,5 @@ frs_stream_fetch <- function(
     if (!is.null(limit)) paste0(" LIMIT ", as.integer(limit))
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_waterbody_network.R
+++ b/R/frs_waterbody_network.R
@@ -19,7 +19,7 @@
 #' @param cols Character vector of column names to select from the polygon
 #'   table. Default includes the most commonly used attributes.
 #' @param direction Character. `"upstream"` (default) or `"downstream"`.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of waterbody polygons.
 #'
@@ -29,27 +29,24 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # Upstream lakes from the Neexdzii Kwa / Wedzin Kwa confluence
-#' lakes <- frs_waterbody_network(
+#' lakes <- frs_waterbody_network(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030
 #' )
 #'
 #' # Upstream wetlands
-#' wetlands <- frs_waterbody_network(
+#' wetlands <- frs_waterbody_network(conn,
 #'   blue_line_key = 360873822,
 #'   downstream_route_measure = 166030,
 #'   table = "whse_basemapping.fwa_wetlands_poly"
 #' )
-#'
-#' # Downstream lakes
-#' lakes_ds <- frs_waterbody_network(
-#'   blue_line_key = 360873822,
-#'   downstream_route_measure = 166030,
-#'   direction = "downstream"
-#' )
+#' DBI::dbDisconnect(conn)
 #' }
 frs_waterbody_network <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     table = "whse_basemapping.fwa_lakes_poly",
@@ -57,8 +54,7 @@ frs_waterbody_network <- function(
       "waterbody_key", "waterbody_type", "gnis_name_1", "area_ha",
       "blue_line_key", "watershed_group_code", "geom"
     ),
-    direction = "upstream",
-    ...
+    direction = "upstream"
 ) {
   direction <- match.arg(direction, c("upstream", "downstream"))
   fwa_fn <- switch(direction,
@@ -98,5 +94,5 @@ frs_waterbody_network <- function(
     table
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/R/frs_watershed_at_measure.R
+++ b/R/frs_watershed_at_measure.R
@@ -18,7 +18,7 @@
 #' @param upstream_blk Integer or `NULL`. Blue line key for the upstream point.
 #'   Defaults to `blue_line_key` (same stream). Use when the upstream point is
 #'   on a tributary.
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame with a single polygon geometry.
 #'
@@ -28,22 +28,26 @@
 #'
 #' @examples
 #' \dontrun{
+#' conn <- frs_db_conn()
+#'
 #' # Watershed upstream of a single point
-#' ws <- frs_watershed_at_measure(360873822, 208877)
+#' ws <- frs_watershed_at_measure(conn, 360873822, 208877)
 #'
 #' # Subbasin between two points on the same stream
-#' aoi <- frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564)
+#' aoi <- frs_watershed_at_measure(conn, 360873822, 208877,
+#'   upstream_measure = 233564)
 #'
 #' # Subbasin with upstream point on a tributary (different BLK)
-#' aoi <- frs_watershed_at_measure(360873822, 165115,
+#' aoi <- frs_watershed_at_measure(conn, 360873822, 165115,
 #'   upstream_measure = 838, upstream_blk = 360886221)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_watershed_at_measure <- function(
+    conn,
     blue_line_key,
     downstream_route_measure,
     upstream_measure = NULL,
-    upstream_blk = NULL,
-    ...
+    upstream_blk = NULL
 ) {
   if (!is.numeric(blue_line_key) || length(blue_line_key) != 1 || is.na(blue_line_key)) {
     stop("blue_line_key must be a single numeric value")
@@ -64,12 +68,20 @@ frs_watershed_at_measure <- function(
     }
   }
 
-  ws_down <- frs_db_query(
+  # Validate upstream > downstream before hitting the DB
+  if (!is.null(upstream_measure)) {
+    up_blk <- if (is.null(upstream_blk)) blue_line_key else upstream_blk
+    if (up_blk == blue_line_key &&
+        upstream_measure <= downstream_route_measure) {
+      stop("upstream_measure must be greater than downstream_route_measure")
+    }
+  }
+
+  ws_down <- frs_db_query(conn,
     sprintf(
       "SELECT geom FROM whse_basemapping.fwa_watershedatmeasure(%s, %s)",
       blue_line_key, downstream_route_measure
-    ),
-    ...
+    )
   )
 
   if (is.null(upstream_measure)) {
@@ -78,17 +90,11 @@ frs_watershed_at_measure <- function(
 
   up_blk <- if (is.null(upstream_blk)) blue_line_key else upstream_blk
 
-  if (up_blk == blue_line_key &&
-      upstream_measure <= downstream_route_measure) {
-    stop("upstream_measure must be greater than downstream_route_measure")
-  }
-
-  ws_up <- frs_db_query(
+  ws_up <- frs_db_query(conn,
     sprintf(
       "SELECT geom FROM whse_basemapping.fwa_watershedatmeasure(%s, %s)",
       up_blk, upstream_measure
-    ),
-    ...
+    )
   )
 
   if (!sf::st_intersects(ws_down, ws_up, sparse = FALSE)[1, 1]) {

--- a/R/frs_watershed_split.R
+++ b/R/frs_watershed_split.R
@@ -21,7 +21,7 @@
 #' @param tolerance Numeric. Maximum snap distance in metres. Default `5000`.
 #' @param crs Target CRS for the output (integer EPSG code, character, or
 #'   `sf::st_crs()` object). Default `NULL` returns WGS84 (EPSG:4326).
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame with columns: `blk`, `drm`, `gnis_name`,
 #'   `area_km2`, any extra columns from the input, and `geometry`.
@@ -63,23 +63,25 @@
 #'   labels = subbasins_no_aoi$name_basin, cex = 0.7, font = 2)
 #'
 #' \dontrun{
-#' # Live: split a watershed from a CSV of break points
+#' conn <- frs_db_conn()
 #' pts <- read.csv(system.file("extdata", "break_points.csv", package = "fresh"))
 #'
 #' # Without AOI — full upstream watersheds, pairwise subtracted
-#' subbasins <- frs_watershed_split(pts)
+#' subbasins <- frs_watershed_split(conn, pts)
 #'
 #' # With AOI — clipped to study area. Include the downstream boundary
 #' # point in break_points.csv for complete tiling with no gaps.
-#' aoi <- frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564)
-#' subbasins <- frs_watershed_split(pts, aoi = aoi)
+#' aoi <- frs_watershed_at_measure(conn, 360873822, 208877,
+#'   upstream_measure = 233564)
+#' subbasins <- frs_watershed_split(conn, pts, aoi = aoi)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_watershed_split <- function(
+    conn,
     points,
     aoi = NULL,
     tolerance = 5000,
-    crs = NULL,
-    ...
+    crs = NULL
 ) {
   if (!is.data.frame(points)) stop("points must be a data frame", call. = FALSE)
   if (!all(c("lon", "lat") %in% names(points))) {
@@ -101,11 +103,10 @@ frs_watershed_split <- function(
   snapped <- list()
   for (i in seq_len(nrow(points))) {
     row <- tryCatch(
-      frs_point_snap(
+      frs_point_snap(conn,
         x = points$lon[i],
         y = points$lat[i],
-        tolerance = tolerance,
-        ...
+        tolerance = tolerance
       ),
       error = function(e) NULL
     )
@@ -136,10 +137,9 @@ frs_watershed_split <- function(
   watersheds <- vector("list", nrow(snapped_df))
   for (j in seq_len(nrow(snapped_df))) {
     ws <- tryCatch(
-      frs_watershed_at_measure(
+      frs_watershed_at_measure(conn,
         snapped_df$blk[j],
-        snapped_df$drm[j],
-        ...
+        snapped_df$drm[j]
       ),
       error = function(e) {
         message(sprintf("Watershed failed for point %d (blk=%d, drm=%.0f): %s",

--- a/R/frs_wetland_fetch.R
+++ b/R/frs_wetland_fetch.R
@@ -15,7 +15,7 @@
 #' @param cols Character vector of column names to select. Default includes
 #'   the most commonly used FWA wetland attributes.
 #' @param limit Integer. Maximum rows to return. Default `NULL` (no limit).
-#' @param ... Additional arguments passed to [frs_db_conn()].
+#' @param conn A [DBI::DBIConnection-class] object (from [frs_db_conn()]).
 #'
 #' @return An `sf` data frame of wetland polygons.
 #'
@@ -25,13 +25,14 @@
 #'
 #' @examples
 #' \dontrun{
-#' # All wetlands in the Bulkley watershed group
-#' wetlands <- frs_wetland_fetch(watershed_group_code = "BULK")
-#'
-#' # Wetlands larger than 5 ha
-#' wetlands <- frs_wetland_fetch(watershed_group_code = "BULK", area_ha_min = 5)
+#' conn <- frs_db_conn()
+#' wetlands <- frs_wetland_fetch(conn, watershed_group_code = "BULK")
+#' wetlands_big <- frs_wetland_fetch(conn, watershed_group_code = "BULK",
+#'   area_ha_min = 5)
+#' DBI::dbDisconnect(conn)
 #' }
 frs_wetland_fetch <- function(
+    conn,
     watershed_group_code = NULL,
     blue_line_key = NULL,
     bbox = NULL,
@@ -41,8 +42,7 @@ frs_wetland_fetch <- function(
       "waterbody_poly_id", "waterbody_key", "waterbody_type", "area_ha",
       "gnis_name_1", "blue_line_key", "watershed_group_code", "geom"
     ),
-    limit = NULL,
-    ...
+    limit = NULL
 ) {
   where <- .frs_build_where(
     watershed_group_code = watershed_group_code,
@@ -60,5 +60,5 @@ frs_wetland_fetch <- function(
     if (!is.null(limit)) paste0(" LIMIT ", as.integer(limit))
   )
 
-  frs_db_query(sql, ...)
+  frs_db_query(conn, sql)
 }

--- a/man/frs_db_query.Rd
+++ b/man/frs_db_query.Rd
@@ -4,25 +4,26 @@
 \alias{frs_db_query}
 \title{Query FWA PostgreSQL Database}
 \usage{
-frs_db_query(query, ...)
+frs_db_query(conn, query)
 }
 \arguments{
-\item{query}{Character. SQL query string.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
 
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
+\item{query}{Character. SQL query string.}
 }
 \value{
 An \code{sf} data frame (if the query returns geometry) or a plain
 data frame.
 }
 \description{
-Connects via \code{\link[=frs_db_conn]{frs_db_conn()}}, executes a SQL query, disconnects, and
-returns the result. Uses \code{\link[sf:st_read]{sf::st_read()}} so spatial columns are returned
-as sf geometry.
+Executes a SQL query on an open connection. Uses \code{\link[sf:st_read]{sf::st_read()}} so
+spatial columns are returned as sf geometry.
 }
 \examples{
 \dontrun{
-frs_db_query("SELECT * FROM whse_basemapping.fwa_lakes_poly LIMIT 5")
+conn <- frs_db_conn()
+frs_db_query(conn, "SELECT * FROM whse_basemapping.fwa_lakes_poly LIMIT 5")
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_fish_habitat.Rd
+++ b/man/frs_fish_habitat.Rd
@@ -5,6 +5,7 @@
 \title{Fetch Modelled Fish Habitat from bcfishpass}
 \usage{
 frs_fish_habitat(
+  conn,
   watershed_group_code = NULL,
   blue_line_key = NULL,
   table = "bcfishpass.streams_vw",
@@ -12,11 +13,12 @@ frs_fish_habitat(
     "downstream_route_measure", "upstream_area_ha", "gnis_name", "stream_order",
     "channel_width", "gradient", "mad_m3s", "watershed_group_code", "wscode",
     "localcode", "geom"),
-  limit = NULL,
-  ...
+  limit = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{watershed_group_code}{Character. Watershed group code. Default \code{NULL}.}
 
 \item{blue_line_key}{Integer. Blue line key. Default \code{NULL}.}
@@ -28,8 +30,6 @@ frs_fish_habitat(
 the most commonly used habitat model attributes.}
 
 \item{limit}{Integer. Maximum rows to return. Default \code{NULL}.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of stream segments with bcfishpass habitat model
@@ -42,8 +42,10 @@ barrier, access, and habitat classification columns.
 }
 \examples{
 \dontrun{
-# Habitat model for the Bulkley
-habitat <- frs_fish_habitat(watershed_group_code = "BULK", limit = 100)
+conn <- frs_db_conn()
+habitat <- frs_fish_habitat(conn, watershed_group_code = "BULK",
+  limit = 100)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_fish_obs.Rd
+++ b/man/frs_fish_obs.Rd
@@ -5,6 +5,7 @@
 \title{Fetch Fish Observations}
 \usage{
 frs_fish_obs(
+  conn,
   species_code = NULL,
   watershed_group_code = NULL,
   blue_line_key = NULL,
@@ -12,11 +13,12 @@ frs_fish_obs(
   cols = c("fish_observation_point_id", "species_code", "observation_date", "life_stage",
     "activity", "blue_line_key", "downstream_route_measure", "watershed_group_code",
     "wscode_ltree", "localcode_ltree", "geom"),
-  limit = NULL,
-  ...
+  limit = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{species_code}{Character. Species code (e.g. \code{"CH"} for chinook,
 \code{"ST"} for steelhead). Default \code{NULL} (all species).}
 
@@ -31,8 +33,6 @@ frs_fish_obs(
 the most commonly used observation attributes.}
 
 \item{limit}{Integer. Maximum rows to return. Default \code{NULL}.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of fish observation events.
@@ -43,8 +43,10 @@ Filter by species code, watershed group, and/or blue line key.
 }
 \examples{
 \dontrun{
-# Chinook observations in the Bulkley
-obs <- frs_fish_obs(species_code = "CH", watershed_group_code = "BULK")
+conn <- frs_db_conn()
+obs <- frs_fish_obs(conn, species_code = "CH",
+  watershed_group_code = "BULK")
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_lake_fetch.Rd
+++ b/man/frs_lake_fetch.Rd
@@ -5,6 +5,7 @@
 \title{Fetch FWA Lakes}
 \usage{
 frs_lake_fetch(
+  conn,
   watershed_group_code = NULL,
   blue_line_key = NULL,
   bbox = NULL,
@@ -12,11 +13,12 @@ frs_lake_fetch(
   table = "whse_basemapping.fwa_lakes_poly",
   cols = c("waterbody_poly_id", "waterbody_key", "waterbody_type", "area_ha",
     "gnis_name_1", "blue_line_key", "watershed_group_code", "geom"),
-  limit = NULL,
-  ...
+  limit = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{watershed_group_code}{Character. Watershed group code (e.g. \code{"BULK"}).
 Default \code{NULL}.}
 
@@ -35,8 +37,6 @@ BC Albers (EPSG:3005). Default \code{NULL}.}
 the most commonly used FWA lake attributes.}
 
 \item{limit}{Integer. Maximum rows to return. Default \code{NULL} (no limit).}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of lake polygons.
@@ -47,11 +47,11 @@ Filter by watershed group code, blue line key, and/or bounding box.
 }
 \examples{
 \dontrun{
-# All lakes in the Bulkley watershed group
-lakes <- frs_lake_fetch(watershed_group_code = "BULK")
-
-# Lakes larger than 10 ha
-lakes <- frs_lake_fetch(watershed_group_code = "BULK", area_ha_min = 10)
+conn <- frs_db_conn()
+lakes <- frs_lake_fetch(conn, watershed_group_code = "BULK")
+lakes_big <- frs_lake_fetch(conn, watershed_group_code = "BULK",
+  area_ha_min = 10)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_network.Rd
+++ b/man/frs_network.Rd
@@ -5,6 +5,7 @@
 \title{Query Multiple Tables Upstream or Downstream of a Network Position}
 \usage{
 frs_network(
+  conn,
   blue_line_key,
   downstream_route_measure,
   upstream_measure = NULL,
@@ -12,11 +13,12 @@ frs_network(
   tables = NULL,
   direction = "upstream",
   include_all = FALSE,
-  clip = NULL,
-  ...
+  clip = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the reference point.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure of the
@@ -49,8 +51,6 @@ these out. Only applied when querying the FWA base table.}
 \item{clip}{An \code{sf} or \code{sfc} polygon to clip results to (e.g. from
 \code{\link[=frs_watershed_at_measure]{frs_watershed_at_measure()}}). Default \code{NULL} (no clipping). Useful for
 waterbody polygons that straddle watershed boundaries. See \code{\link[=frs_clip]{frs_clip()}}.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 A named list of \code{sf} data frames (or plain data frames for tables
@@ -73,22 +73,25 @@ key (e.g. a tributary) by specifying \code{upstream_blk}.
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
 blk <- 360873822
 
 # Everything upstream of a point
-streams <- frs_network(blk, 166030)
+streams <- frs_network(conn, blk, 166030)
 
 # Between two points (subbasin): upstream of Byman minus upstream of Ailport
-result <- frs_network(blk, 208877, upstream_measure = 233564, tables = list(
-  streams = "whse_basemapping.fwa_stream_networks_sp",
-  lakes = "whse_basemapping.fwa_lakes_poly",
-  crossings = "bcfishpass.crossings",
-  observations = list(
-    table = "bcfishpass.observations_vw",
-    wscode_col = "wscode",
-    localcode_col = "localcode"
-  )
-))
+result <- frs_network(conn, blk, 208877, upstream_measure = 233564,
+  tables = list(
+    streams = "whse_basemapping.fwa_stream_networks_sp",
+    lakes = "whse_basemapping.fwa_lakes_poly",
+    crossings = "bcfishpass.crossings",
+    observations = list(
+      table = "bcfishpass.observations_vw",
+      wscode_col = "wscode",
+      localcode_col = "localcode"
+    )
+  ))
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_network_downstream.Rd
+++ b/man/frs_network_downstream.Rd
@@ -5,6 +5,7 @@
 \title{Get Stream Segments Downstream of a Network Position}
 \usage{
 frs_network_downstream(
+  conn,
   blue_line_key,
   downstream_route_measure,
   table = "whse_basemapping.fwa_stream_networks_sp",
@@ -14,11 +15,12 @@ frs_network_downstream(
     "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"),
   wscode_col = "wscode_ltree",
   localcode_col = "localcode_ltree",
-  include_all = FALSE,
-  ...
+  include_all = FALSE
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the reference point.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure of the
@@ -39,8 +41,6 @@ Default \code{"localcode_ltree"}. Use \code{"localcode"} for bcfishpass views.}
 \item{include_all}{Logical. If \code{TRUE}, include placeholder streams (999
 wscode) and unmapped tributaries (NULL localcode). Default \code{FALSE} filters
 these out. Only applied when querying the FWA base table.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of downstream stream segments.
@@ -51,11 +51,12 @@ downstream route measure. Uses the fwapg \code{fwa_downstream()} ltree compariso
 }
 \examples{
 \dontrun{
-# Get all streams downstream of a point
-downstream <- frs_network_downstream(
+conn <- frs_db_conn()
+downstream <- frs_network_downstream(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030
 )
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_network_prune.Rd
+++ b/man/frs_network_prune.Rd
@@ -5,6 +5,7 @@
 \title{Get Pruned Upstream Network}
 \usage{
 frs_network_prune(
+  conn,
   blue_line_key,
   downstream_route_measure,
   stream_order_min = NULL,
@@ -18,11 +19,12 @@ frs_network_prune(
     "downstream_route_measure", "upstream_route_measure", "length_metre",
     "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"),
   wscode_col = "wscode_ltree",
-  localcode_col = "localcode_ltree",
-  ...
+  localcode_col = "localcode_ltree"
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the reference point.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure of the
@@ -54,8 +56,6 @@ Default \code{"wscode_ltree"}. Use \code{"wscode"} for bcfishpass views.}
 
 \item{localcode_col}{Character. Name of the local code ltree column.
 Default \code{"localcode_ltree"}. Use \code{"localcode"} for bcfishpass views.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of filtered upstream stream segments.
@@ -74,8 +74,10 @@ to a gap in the bcfishpass rearing model. See
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # Upstream network from FWA base table, order >= 3
-pruned <- frs_network_prune(
+pruned <- frs_network_prune(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030,
   stream_order_min = 3,
@@ -84,7 +86,7 @@ pruned <- frs_network_prune(
 
 # Coho rearing/spawning upstream of Neexdzii Kwa confluence
 # NB: rearing/spawning filters drop lake/wetland segments (see @note)
-co_habitat <- frs_network_prune(
+co_habitat <- frs_network_prune(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030.4,
   stream_order_min = 4,
@@ -97,6 +99,7 @@ co_habitat <- frs_network_prune(
   wscode_col = "wscode",
   localcode_col = "localcode"
 )
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_network_upstream.Rd
+++ b/man/frs_network_upstream.Rd
@@ -5,6 +5,7 @@
 \title{Get Stream Segments Upstream of a Network Position}
 \usage{
 frs_network_upstream(
+  conn,
   blue_line_key,
   downstream_route_measure,
   table = "whse_basemapping.fwa_stream_networks_sp",
@@ -14,11 +15,12 @@ frs_network_upstream(
     "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"),
   wscode_col = "wscode_ltree",
   localcode_col = "localcode_ltree",
-  include_all = FALSE,
-  ...
+  include_all = FALSE
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the reference point.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure of the
@@ -39,8 +41,6 @@ Default \code{"localcode_ltree"}. Use \code{"localcode"} for bcfishpass views.}
 \item{include_all}{Logical. If \code{TRUE}, include placeholder streams (999
 wscode) and unmapped tributaries (NULL localcode). Default \code{FALSE} filters
 these out. Only applied when querying the FWA base table.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of upstream stream segments.
@@ -51,20 +51,23 @@ downstream route measure. Uses the fwapg \code{fwa_upstream()} ltree comparison.
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # Get all streams upstream of a point on the Bulkley
-upstream <- frs_network_upstream(
+upstream <- frs_network_upstream(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030
 )
 
 # Use bcfishpass coho view
-upstream <- frs_network_upstream(
+upstream <- frs_network_upstream(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030,
   table = "bcfishpass.streams_co_vw",
   wscode_col = "wscode",
   localcode_col = "localcode"
 )
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_params.Rd
+++ b/man/frs_params.Rd
@@ -11,8 +11,9 @@ frs_params(
 )
 }
 \arguments{
-\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object. Required when reading
-from a database table. Ignored when \code{csv} is provided.}
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).
+Required when reading from a database table. Use \code{NULL} when reading
+from a CSV file.}
 
 \item{table}{Character. Schema-qualified table name to read parameters from.
 Default \code{"bcfishpass.parameters_habitat_thresholds"}.}

--- a/man/frs_point_locate.Rd
+++ b/man/frs_point_locate.Rd
@@ -4,14 +4,14 @@
 \alias{frs_point_locate}
 \title{Locate a Point on the FWA Stream Network}
 \usage{
-frs_point_locate(blue_line_key, downstream_route_measure, ...)
+frs_point_locate(conn, blue_line_key, downstream_route_measure)
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the stream.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure in metres.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame with a single point geometry.
@@ -22,8 +22,10 @@ geometry on the stream network. Wraps fwapg \code{fwa_locatealong()}.
 }
 \examples{
 \dontrun{
-# Get the point at measure 1000 on a stream
-pt <- frs_point_locate(blue_line_key = 360873822, downstream_route_measure = 1000)
+conn <- frs_db_conn()
+pt <- frs_point_locate(conn, blue_line_key = 360873822,
+  downstream_route_measure = 1000)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_point_snap.Rd
+++ b/man/frs_point_snap.Rd
@@ -5,17 +5,19 @@
 \title{Snap a Point to the Nearest FWA Stream}
 \usage{
 frs_point_snap(
+  conn,
   x,
   y,
   srid = 4326L,
   tolerance = 5000,
   num_features = 1L,
   blue_line_key = NULL,
-  stream_order_min = NULL,
-  ...
+  stream_order_min = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{x}{Numeric. Longitude or easting.}
 
 \item{y}{Numeric. Latitude or northing.}
@@ -33,8 +35,6 @@ stream. Bypasses \code{fwa_indexpoint()} and uses KNN against
 
 \item{stream_order_min}{Integer. Optional. Minimum stream order for snap
 candidates. Ignored when \code{blue_line_key} is provided. Forces KNN path.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame with columns: \code{linear_feature_id}, \code{gnis_name},
@@ -50,14 +50,18 @@ filtered to that stream, with measure derivation and boundary clamping
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # Snap to nearest stream (any)
-snapped <- frs_point_snap(x = -126.5, y = 54.5)
+snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 
 # Snap to a specific stream (Bulkley River)
-snapped <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+snapped <- frs_point_snap(conn, x = -126.5, y = 54.5,
+  blue_line_key = 360873822)
 
 # Snap to order 4+ streams only
-snapped <- frs_point_snap(x = -126.5, y = 54.5, stream_order_min = 4)
+snapped <- frs_point_snap(conn, x = -126.5, y = 54.5, stream_order_min = 4)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_stream_fetch.Rd
+++ b/man/frs_stream_fetch.Rd
@@ -5,6 +5,7 @@
 \title{Fetch FWA Stream Network Segments}
 \usage{
 frs_stream_fetch(
+  conn,
   watershed_group_code = NULL,
   blue_line_key = NULL,
   bbox = NULL,
@@ -15,11 +16,12 @@ frs_stream_fetch(
     "downstream_route_measure", "upstream_route_measure", "length_metre",
     "watershed_group_code", "wscode_ltree", "localcode_ltree", "geom"),
   include_all = FALSE,
-  limit = NULL,
-  ...
+  limit = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{watershed_group_code}{Character. Watershed group code (e.g. \code{"BULK"}).
 Default \code{NULL}.}
 
@@ -43,8 +45,6 @@ wscode) and unmapped tributaries (NULL localcode). Default \code{FALSE} filters
 these out. Only applied when querying the FWA base table.}
 
 \item{limit}{Integer. Maximum rows to return. Default \code{NULL} (no limit).}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of stream segments.
@@ -55,17 +55,15 @@ Filter by watershed group code, blue line key, and/or bounding box.
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # All streams in the Bulkley watershed group
-streams <- frs_stream_fetch(watershed_group_code = "BULK")
+streams <- frs_stream_fetch(conn, watershed_group_code = "BULK")
 
 # Streams with order >= 4
-streams <- frs_stream_fetch(watershed_group_code = "BULK", stream_order_min = 4)
-
-# Custom columns and table
-streams <- frs_stream_fetch(
-  watershed_group_code = "BULK",
-  cols = c("blue_line_key", "gnis_name", "stream_order", "geom")
-)
+streams <- frs_stream_fetch(conn, watershed_group_code = "BULK",
+  stream_order_min = 4)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_waterbody_network.Rd
+++ b/man/frs_waterbody_network.Rd
@@ -5,16 +5,18 @@
 \title{Get Waterbody Polygons Upstream or Downstream of a Network Position}
 \usage{
 frs_waterbody_network(
+  conn,
   blue_line_key,
   downstream_route_measure,
   table = "whse_basemapping.fwa_lakes_poly",
   cols = c("waterbody_key", "waterbody_type", "gnis_name_1", "area_ha", "blue_line_key",
     "watershed_group_code", "geom"),
-  direction = "upstream",
-  ...
+  direction = "upstream"
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. Blue line key of the reference point.}
 
 \item{downstream_route_measure}{Numeric. Downstream route measure of the
@@ -27,8 +29,6 @@ reference point.}
 table. Default includes the most commonly used attributes.}
 
 \item{direction}{Character. \code{"upstream"} (default) or \code{"downstream"}.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of waterbody polygons.
@@ -48,25 +48,21 @@ background.
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # Upstream lakes from the Neexdzii Kwa / Wedzin Kwa confluence
-lakes <- frs_waterbody_network(
+lakes <- frs_waterbody_network(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030
 )
 
 # Upstream wetlands
-wetlands <- frs_waterbody_network(
+wetlands <- frs_waterbody_network(conn,
   blue_line_key = 360873822,
   downstream_route_measure = 166030,
   table = "whse_basemapping.fwa_wetlands_poly"
 )
-
-# Downstream lakes
-lakes_ds <- frs_waterbody_network(
-  blue_line_key = 360873822,
-  downstream_route_measure = 166030,
-  direction = "downstream"
-)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_watershed_at_measure.Rd
+++ b/man/frs_watershed_at_measure.Rd
@@ -5,14 +5,16 @@
 \title{Watershed at Measure}
 \usage{
 frs_watershed_at_measure(
+  conn,
   blue_line_key,
   downstream_route_measure,
   upstream_measure = NULL,
-  upstream_blk = NULL,
-  ...
+  upstream_blk = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{blue_line_key}{Integer. FWA blue line key identifying the stream.}
 
 \item{downstream_route_measure}{Numeric. Route measure of the downstream
@@ -25,8 +27,6 @@ point. When provided, returns the watershed between the two measures
 \item{upstream_blk}{Integer or \code{NULL}. Blue line key for the upstream point.
 Defaults to \code{blue_line_key} (same stream). Use when the upstream point is
 on a tributary.}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame with a single polygon geometry.
@@ -44,15 +44,19 @@ by specifying \code{upstream_blk}.
 }
 \examples{
 \dontrun{
+conn <- frs_db_conn()
+
 # Watershed upstream of a single point
-ws <- frs_watershed_at_measure(360873822, 208877)
+ws <- frs_watershed_at_measure(conn, 360873822, 208877)
 
 # Subbasin between two points on the same stream
-aoi <- frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564)
+aoi <- frs_watershed_at_measure(conn, 360873822, 208877,
+  upstream_measure = 233564)
 
 # Subbasin with upstream point on a tributary (different BLK)
-aoi <- frs_watershed_at_measure(360873822, 165115,
+aoi <- frs_watershed_at_measure(conn, 360873822, 165115,
   upstream_measure = 838, upstream_blk = 360886221)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_watershed_split.Rd
+++ b/man/frs_watershed_split.Rd
@@ -4,9 +4,11 @@
 \alias{frs_watershed_split}
 \title{Split a Watershed into Sub-Basins at Break Points}
 \usage{
-frs_watershed_split(points, aoi = NULL, tolerance = 5000, crs = NULL, ...)
+frs_watershed_split(conn, points, aoi = NULL, tolerance = 5000, crs = NULL)
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{points}{A data frame (or sf) with \code{lon} and \code{lat} columns (WGS84).
 All extra columns (e.g. \code{name_basin}) are preserved in the output,
 making this the place to attach labels, site IDs, or any metadata to
@@ -21,8 +23,6 @@ downstream point as a break point to get complete tiling with no gaps
 
 \item{crs}{Target CRS for the output (integer EPSG code, character, or
 \code{sf::st_crs()} object). Default \code{NULL} returns WGS84 (EPSG:4326).}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame with columns: \code{blk}, \code{drm}, \code{gnis_name},
@@ -72,16 +72,18 @@ text(sf::st_coordinates(sf::st_centroid(subbasins_no_aoi)),
   labels = subbasins_no_aoi$name_basin, cex = 0.7, font = 2)
 
 \dontrun{
-# Live: split a watershed from a CSV of break points
+conn <- frs_db_conn()
 pts <- read.csv(system.file("extdata", "break_points.csv", package = "fresh"))
 
 # Without AOI — full upstream watersheds, pairwise subtracted
-subbasins <- frs_watershed_split(pts)
+subbasins <- frs_watershed_split(conn, pts)
 
 # With AOI — clipped to study area. Include the downstream boundary
 # point in break_points.csv for complete tiling with no gaps.
-aoi <- frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564)
-subbasins <- frs_watershed_split(pts, aoi = aoi)
+aoi <- frs_watershed_at_measure(conn, 360873822, 208877,
+  upstream_measure = 233564)
+subbasins <- frs_watershed_split(conn, pts, aoi = aoi)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/man/frs_wetland_fetch.Rd
+++ b/man/frs_wetland_fetch.Rd
@@ -5,6 +5,7 @@
 \title{Fetch FWA Wetlands}
 \usage{
 frs_wetland_fetch(
+  conn,
   watershed_group_code = NULL,
   blue_line_key = NULL,
   bbox = NULL,
@@ -12,11 +13,12 @@ frs_wetland_fetch(
   table = "whse_basemapping.fwa_wetlands_poly",
   cols = c("waterbody_poly_id", "waterbody_key", "waterbody_type", "area_ha",
     "gnis_name_1", "blue_line_key", "watershed_group_code", "geom"),
-  limit = NULL,
-  ...
+  limit = NULL
 )
 }
 \arguments{
+\item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
+
 \item{watershed_group_code}{Character. Watershed group code (e.g. \code{"BULK"}).
 Default \code{NULL}.}
 
@@ -35,8 +37,6 @@ BC Albers (EPSG:3005). Default \code{NULL}.}
 the most commonly used FWA wetland attributes.}
 
 \item{limit}{Integer. Maximum rows to return. Default \code{NULL} (no limit).}
-
-\item{...}{Additional arguments passed to \code{\link[=frs_db_conn]{frs_db_conn()}}.}
 }
 \value{
 An \code{sf} data frame of wetland polygons.
@@ -47,11 +47,11 @@ Filter by watershed group code, blue line key, and/or bounding box.
 }
 \examples{
 \dontrun{
-# All wetlands in the Bulkley watershed group
-wetlands <- frs_wetland_fetch(watershed_group_code = "BULK")
-
-# Wetlands larger than 5 ha
-wetlands <- frs_wetland_fetch(watershed_group_code = "BULK", area_ha_min = 5)
+conn <- frs_db_conn()
+wetlands <- frs_wetland_fetch(conn, watershed_group_code = "BULK")
+wetlands_big <- frs_wetland_fetch(conn, watershed_group_code = "BULK",
+  area_ha_min = 5)
+DBI::dbDisconnect(conn)
 }
 }
 \seealso{

--- a/tests/testthat/test-frs_db_query.R
+++ b/tests/testthat/test-frs_db_query.R
@@ -1,7 +1,9 @@
 test_that("frs_db_query returns sf from spatial query", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  result <- frs_db_query(
+  result <- frs_db_query(conn,
     "SELECT * FROM whse_basemapping.fwa_lakes_poly LIMIT 3"
   )
   expect_s3_class(result, "sf")

--- a/tests/testthat/test-frs_fish_habitat.R
+++ b/tests/testthat/test-frs_fish_habitat.R
@@ -1,7 +1,9 @@
 test_that("frs_fish_habitat returns sf with bcfishpass columns", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  habitat <- frs_fish_habitat(watershed_group_code = "BULK", limit = 5)
+  habitat <- frs_fish_habitat(conn, watershed_group_code = "BULK", limit = 5)
   expect_s3_class(habitat, "sf")
   expect_true(nrow(habitat) > 0)
   expect_true("gradient" %in% names(habitat))

--- a/tests/testthat/test-frs_fish_obs.R
+++ b/tests/testthat/test-frs_fish_obs.R
@@ -1,7 +1,9 @@
 test_that("frs_fish_obs returns sf with species filter", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  obs <- frs_fish_obs(species_code = "CH", watershed_group_code = "BULK", limit = 5)
+  obs <- frs_fish_obs(conn, species_code = "CH", watershed_group_code = "BULK", limit = 5)
   expect_s3_class(obs, "sf")
   expect_true(nrow(obs) > 0)
   expect_true("species_code" %in% names(obs))
@@ -10,8 +12,10 @@ test_that("frs_fish_obs returns sf with species filter", {
 
 test_that("frs_fish_obs returns all species when unfiltered", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  obs <- frs_fish_obs(watershed_group_code = "BULK", limit = 10)
+  obs <- frs_fish_obs(conn, watershed_group_code = "BULK", limit = 10)
   expect_s3_class(obs, "sf")
   expect_true(nrow(obs) > 0)
 })

--- a/tests/testthat/test-frs_lake_fetch.R
+++ b/tests/testthat/test-frs_lake_fetch.R
@@ -1,7 +1,9 @@
 test_that("frs_lake_fetch returns sf with watershed_group_code filter", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  lakes <- frs_lake_fetch(watershed_group_code = "BULK", limit = 5)
+  lakes <- frs_lake_fetch(conn, watershed_group_code = "BULK", limit = 5)
   expect_s3_class(lakes, "sf")
   expect_true(nrow(lakes) > 0)
   expect_true("waterbody_key" %in% names(lakes))
@@ -10,8 +12,10 @@ test_that("frs_lake_fetch returns sf with watershed_group_code filter", {
 
 test_that("frs_lake_fetch filters by area_ha_min", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  lakes <- frs_lake_fetch(
+  lakes <- frs_lake_fetch(conn,
     watershed_group_code = "BULK",
     area_ha_min = 100,
     limit = 10

--- a/tests/testthat/test-frs_network.R
+++ b/tests/testthat/test-frs_network.R
@@ -1,11 +1,11 @@
 test_that("frs_network with no tables returns streams directly", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  result <- frs_network(360873822, 166030)
+  result <- frs_network("mock", 360873822, 166030)
 
   expect_match(sql_sent, "fwa_stream_networks_sp")
   expect_match(sql_sent, "fwa_upstream")
@@ -13,9 +13,9 @@ test_that("frs_network with no tables returns streams directly", {
 })
 
 test_that("frs_network returns named list for multiple tables", {
-  local_mocked_bindings(frs_db_query = function(sql, ...) data.frame())
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) data.frame())
 
-  result <- frs_network(360873822, 166030, tables = list(
+  result <- frs_network("mock", 360873822, 166030, tables = list(
     streams = "whse_basemapping.fwa_stream_networks_sp",
     lakes = "whse_basemapping.fwa_lakes_poly"
   ))
@@ -26,12 +26,12 @@ test_that("frs_network returns named list for multiple tables", {
 
 test_that("frs_network detects waterbody bridge for lakes", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     lakes = "whse_basemapping.fwa_lakes_poly"
   ))
 
@@ -42,12 +42,12 @@ test_that("frs_network detects waterbody bridge for lakes", {
 
 test_that("frs_network detects waterbody bridge for wetlands", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     wetlands = "whse_basemapping.fwa_wetlands_poly"
   ))
 
@@ -57,12 +57,12 @@ test_that("frs_network detects waterbody bridge for wetlands", {
 
 test_that("frs_network uses direct query for crossings", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     crossings = "bcfishpass.crossings"
   ))
 
@@ -74,13 +74,13 @@ test_that("frs_network uses direct query for crossings", {
 test_that("frs_network passes direction downstream", {
   sqls <- list()
   call_n <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_n <<- call_n + 1
     sqls[[call_n]] <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030,
+  frs_network("mock", 360873822, 166030,
     tables = list(
       streams = "whse_basemapping.fwa_stream_networks_sp",
       lakes = "whse_basemapping.fwa_lakes_poly"
@@ -94,12 +94,12 @@ test_that("frs_network passes direction downstream", {
 
 test_that("frs_network passes custom cols and wscode_col", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     co = list(
       table = "bcfishpass.streams_co_vw",
       cols = c("blue_line_key", "mapping_code", "geom"),
@@ -117,12 +117,12 @@ test_that("frs_network passes custom cols and wscode_col", {
 
 test_that("frs_network passes extra_where", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     co = list(
       table = "bcfishpass.streams_co_vw",
       wscode_col = "wscode",
@@ -145,64 +145,64 @@ test_that("frs_default_cols returns sensible defaults", {
 })
 
 test_that("frs_network rejects NULL blue_line_key", {
-  expect_error(frs_network(NULL, 166030), "single numeric")
+  expect_error(frs_network("mock", NULL, 166030), "single numeric")
 })
 
 test_that("frs_network rejects NA blue_line_key", {
-  expect_error(frs_network(NA, 166030), "single numeric")
+  expect_error(frs_network("mock", NA, 166030), "single numeric")
 })
 
 test_that("frs_network rejects character blue_line_key", {
-  expect_error(frs_network("abc", 166030), "single numeric")
+  expect_error(frs_network("mock", "abc", 166030), "single numeric")
 })
 
 test_that("frs_network rejects NA downstream_route_measure", {
-  expect_error(frs_network(360873822, NA), "single numeric")
+  expect_error(frs_network("mock", 360873822, NA), "single numeric")
 })
 
 test_that("frs_network rejects vector measure", {
-  expect_error(frs_network(360873822, c(100, 200)), "single numeric")
+  expect_error(frs_network("mock", 360873822, c(100, 200)), "single numeric")
 })
 
 test_that("frs_network rejects NA upstream_measure", {
-  expect_error(frs_network(360873822, 166030, upstream_measure = NA), "single numeric")
+  expect_error(frs_network("mock", 360873822, 166030, upstream_measure = NA), "single numeric")
 })
 
 test_that("frs_network rejects character upstream_blk", {
   expect_error(
-    frs_network(360873822, 166030, upstream_measure = 200000, upstream_blk = "bad"),
+    frs_network("mock", 360873822, 166030, upstream_measure = 200000, upstream_blk = "bad"),
     "single numeric"
   )
 })
 
 test_that("frs_network rejects invalid direction", {
-  expect_error(frs_network(360873822, 166030, direction = "sideways"), "arg")
+  expect_error(frs_network("mock", 360873822, 166030, direction = "sideways"), "arg")
 })
 
 test_that("upstream_measure with downstream direction errors", {
   expect_error(
-    frs_network(360873822, 166030, upstream_measure = 200000, direction = "downstream"),
+    frs_network("mock", 360873822, 166030, upstream_measure = 200000, direction = "downstream"),
     "upstream_measure"
   )
 })
 
 test_that("upstream_measure <= downstream_route_measure errors on same BLK", {
   expect_error(
-    frs_network(360873822, 200000, upstream_measure = 100000),
+    frs_network("mock", 360873822, 200000, upstream_measure = 100000),
     "greater"
   )
 })
 
 test_that("upstream_blk skips measure check for different BLK", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     if (grepl("is_upstream", sql)) return(data.frame(is_upstream = TRUE))
     sql_sent <<- sql
     data.frame()
   })
 
   # upstream_measure < downstream_route_measure but on different BLK — should NOT error
-  frs_network(360873822, 208877, upstream_measure = 838,
+  frs_network("mock", 360873822, 208877, upstream_measure = 838,
     upstream_blk = 360886221, tables = list(
       streams = "whse_basemapping.fwa_stream_networks_sp"
     ))
@@ -214,13 +214,13 @@ test_that("upstream_blk skips measure check for different BLK", {
 
 test_that("upstream_blk uses different BLK in ref_up for direct table", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     if (grepl("is_upstream", sql)) return(data.frame(is_upstream = TRUE))
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 165115, upstream_measure = 838,
+  frs_network("mock", 360873822, 165115, upstream_measure = 838,
     upstream_blk = 360886221, tables = list(
       crossings = "bcfishpass.crossings"
     ))
@@ -234,7 +234,7 @@ test_that("upstream_blk uses different BLK in ref_up for direct table", {
 
 test_that("upstream_blk on different network errors", {
   call_count <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_count <<- call_count + 1
     if (grepl("fwa_upstream", sql)) {
       # Validation query — not upstream
@@ -245,7 +245,7 @@ test_that("upstream_blk on different network errors", {
   })
 
   expect_error(
-    frs_network(360873822, 208877, upstream_measure = 79244,
+    frs_network("mock", 360873822, 208877, upstream_measure = 79244,
       upstream_blk = 356570562, tables = list(
         streams = "whse_basemapping.fwa_stream_networks_sp"
       )),
@@ -255,7 +255,7 @@ test_that("upstream_blk on different network errors", {
 
 test_that("upstream_blk on same network passes validation", {
   call_count <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_count <<- call_count + 1
     if (grepl("fwa_upstream\\(", sql) && grepl("is_upstream", sql)) {
       data.frame(is_upstream = TRUE)
@@ -264,7 +264,7 @@ test_that("upstream_blk on same network passes validation", {
     }
   })
 
-  result <- frs_network(360873822, 165115, upstream_measure = 838,
+  result <- frs_network("mock", 360873822, 165115, upstream_measure = 838,
     upstream_blk = 360886221, tables = list(
       streams = "whse_basemapping.fwa_stream_networks_sp"
     ))
@@ -275,13 +275,13 @@ test_that("upstream_blk on same network passes validation", {
 
 test_that("upstream_blk uses different BLK in ref_up for waterbody table", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     if (grepl("is_upstream", sql)) return(data.frame(is_upstream = TRUE))
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 165115, upstream_measure = 838,
+  frs_network("mock", 360873822, 165115, upstream_measure = 838,
     upstream_blk = 360886221, tables = list(
       lakes = "whse_basemapping.fwa_lakes_poly"
     ))
@@ -293,12 +293,12 @@ test_that("upstream_blk uses different BLK in ref_up for waterbody table", {
 
 test_that("upstream_measure generates between SQL for direct table", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 208877, upstream_measure = 233564, tables = list(
+  frs_network("mock", 360873822, 208877, upstream_measure = 233564, tables = list(
     streams = "whse_basemapping.fwa_stream_networks_sp"
   ))
 
@@ -311,12 +311,12 @@ test_that("upstream_measure generates between SQL for direct table", {
 
 test_that("upstream_measure generates between SQL for waterbody table", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 208877, upstream_measure = 233564, tables = list(
+  frs_network("mock", 360873822, 208877, upstream_measure = 233564, tables = list(
     lakes = "whse_basemapping.fwa_lakes_poly"
   ))
 
@@ -328,12 +328,12 @@ test_that("upstream_measure generates between SQL for waterbody table", {
 
 test_that("upstream_measure NULL preserves single-ref SQL", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030)
+  frs_network("mock", 360873822, 166030)
 
   expect_match(sql_sent, "WITH ref AS")
   expect_no_match(sql_sent, "ref_down")
@@ -342,20 +342,20 @@ test_that("upstream_measure NULL preserves single-ref SQL", {
 
 test_that("upstream_blk without upstream_measure is ignored", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
   # upstream_blk provided but upstream_measure is NULL — no subtraction
-  frs_network(360873822, 166030, upstream_blk = 360886221)
+  frs_network("mock", 360873822, 166030, upstream_blk = 360886221)
   expect_match(sql_sent, "WITH ref AS")
   expect_no_match(sql_sent, "ref_down")
 })
 
 test_that("frs_network equal measures on same BLK errors", {
   expect_error(
-    frs_network(360873822, 208877, upstream_measure = 208877),
+    frs_network("mock", 360873822, 208877, upstream_measure = 208877),
     "greater"
   )
 })
@@ -363,7 +363,7 @@ test_that("frs_network equal measures on same BLK errors", {
 test_that("frs_network same BLK passed as upstream_blk still checks measures", {
   # Explicitly passing upstream_blk = same as blue_line_key should still enforce measure check
   expect_error(
-    frs_network(360873822, 200000, upstream_measure = 100000,
+    frs_network("mock", 360873822, 200000, upstream_measure = 100000,
       upstream_blk = 360873822),
     "greater"
   )
@@ -371,14 +371,14 @@ test_that("frs_network same BLK passed as upstream_blk still checks measures", {
 
 test_that("frs_network upstream_blk with downstream direction errors", {
   expect_error(
-    frs_network(360873822, 166030, upstream_measure = 838,
+    frs_network("mock", 360873822, 166030, upstream_measure = 838,
       upstream_blk = 360886221, direction = "downstream"),
     "upstream_measure"
   )
 })
 
 test_that("frs_check_upstream errors on empty result", {
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     if (grepl("is_upstream", sql)) {
       # Empty result — BLK not found in stream network
       data.frame(is_upstream = logical(0))
@@ -388,7 +388,7 @@ test_that("frs_check_upstream errors on empty result", {
   })
 
   expect_error(
-    frs_network(360873822, 208877, upstream_measure = 838,
+    frs_network("mock", 360873822, 208877, upstream_measure = 838,
       upstream_blk = 999999999, tables = list(
         streams = "whse_basemapping.fwa_stream_networks_sp"
       )),
@@ -398,12 +398,12 @@ test_that("frs_check_upstream errors on empty result", {
 
 test_that("upstream_measure with custom wscode_col", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 208877, upstream_measure = 233564, tables = list(
+  frs_network("mock", 360873822, 208877, upstream_measure = 233564, tables = list(
     obs = list(
       table = "bcfishpass.observations_vw",
       wscode_col = "wscode",
@@ -423,12 +423,12 @@ test_that("upstream_measure with custom wscode_col", {
 
 test_that("frs_network includes guards for FWA streams by default", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030)
+  frs_network("mock", 360873822, 166030)
 
   expect_match(sql_sent, "localcode_ltree IS NOT NULL")
   expect_match(sql_sent, "wscode_ltree <@ '999'")
@@ -436,12 +436,12 @@ test_that("frs_network includes guards for FWA streams by default", {
 
 test_that("frs_network skips guards with include_all = TRUE", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, include_all = TRUE)
+  frs_network("mock", 360873822, 166030, include_all = TRUE)
 
   expect_no_match(sql_sent, "edge_type NOT IN")
   expect_no_match(sql_sent, "wscode_ltree <@ '999'")
@@ -449,12 +449,12 @@ test_that("frs_network skips guards with include_all = TRUE", {
 
 test_that("frs_network includes guards in waterbody CTE", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     lakes = "whse_basemapping.fwa_lakes_poly"
   ))
 
@@ -463,12 +463,12 @@ test_that("frs_network includes guards in waterbody CTE", {
 
 test_that("frs_network skips guards for non-FWA tables", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network(360873822, 166030, tables = list(
+  frs_network("mock", 360873822, 166030, tables = list(
     streams = list(
       table = "bcfishpass.streams_co_vw",
       wscode_col = "wscode",
@@ -490,7 +490,7 @@ test_that("frs_network clip param clips results", {
       crs = 4326
     )
   )
-  local_mocked_bindings(frs_db_query = function(sql, ...) mock_sf)
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) mock_sf)
 
   aoi <- sf::st_sf(
     geom = sf::st_sfc(
@@ -499,7 +499,7 @@ test_that("frs_network clip param clips results", {
     )
   )
 
-  result <- frs_network(360873822, 166030, clip = aoi)
+  result <- frs_network("mock", 360873822, 166030, clip = aoi)
   # Only first polygon intersects, and it should be clipped smaller
   expect_true(nrow(result) == 1L)
 })

--- a/tests/testthat/test-frs_network_downstream.R
+++ b/tests/testthat/test-frs_network_downstream.R
@@ -5,12 +5,12 @@ test_that("guards are included by default for FWA base table", {
     linear_feature_id = 1L, geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "localcode_ltree IS NOT NULL")
       mock_result
     }
   )
-  frs_network_downstream(blue_line_key = 360873822, downstream_route_measure = 166030)
+  frs_network_downstream("mock", blue_line_key = 360873822, downstream_route_measure = 166030)
 })
 
 test_that("guards are skipped with include_all = TRUE", {
@@ -18,12 +18,12 @@ test_that("guards are skipped with include_all = TRUE", {
     linear_feature_id = 1L, geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_no_match(sql, "edge_type NOT IN")
       mock_result
     }
   )
-  frs_network_downstream(blue_line_key = 360873822, downstream_route_measure = 166030,
+  frs_network_downstream("mock", blue_line_key = 360873822, downstream_route_measure = 166030,
     include_all = TRUE)
 })
 
@@ -31,10 +31,12 @@ test_that("guards are skipped with include_all = TRUE", {
 
 test_that("frs_network_downstream returns sf of downstream segments", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 
-  downstream <- frs_network_downstream(
+  downstream <- frs_network_downstream(conn,
     blue_line_key = snapped$blue_line_key,
     downstream_route_measure = snapped$downstream_route_measure
   )

--- a/tests/testthat/test-frs_network_prune.R
+++ b/tests/testthat/test-frs_network_prune.R
@@ -2,24 +2,24 @@
 
 test_that("frs_network_prune includes guards by default", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network_prune(blue_line_key = 360873822, downstream_route_measure = 166030)
+  frs_network_prune("mock", blue_line_key = 360873822, downstream_route_measure = 166030)
 
   expect_match(sql_sent, "localcode_ltree IS NOT NULL")
 })
 
 test_that("frs_network_prune skips guards with include_all = TRUE", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_network_prune(blue_line_key = 360873822, downstream_route_measure = 166030,
+  frs_network_prune("mock", blue_line_key = 360873822, downstream_route_measure = 166030,
     include_all = TRUE)
 
   expect_no_match(sql_sent, "edge_type NOT IN")
@@ -29,10 +29,12 @@ test_that("frs_network_prune skips guards with include_all = TRUE", {
 
 test_that("frs_network_prune filters upstream by stream order", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 
-  pruned <- frs_network_prune(
+  pruned <- frs_network_prune(conn,
     blue_line_key = snapped$blue_line_key,
     downstream_route_measure = snapped$downstream_route_measure,
     stream_order_min = 3
@@ -45,10 +47,12 @@ test_that("frs_network_prune filters upstream by stream order", {
 
 test_that("frs_network_prune filters by gradient", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 
-  pruned <- frs_network_prune(
+  pruned <- frs_network_prune(conn,
     blue_line_key = snapped$blue_line_key,
     downstream_route_measure = snapped$downstream_route_measure,
     gradient_max = 0.03

--- a/tests/testthat/test-frs_network_upstream.R
+++ b/tests/testthat/test-frs_network_upstream.R
@@ -5,13 +5,13 @@ test_that("guards are included by default for FWA base table", {
     linear_feature_id = 1L, geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "localcode_ltree IS NOT NULL")
       expect_match(sql, "wscode_ltree <@ '999'")
       mock_result
     }
   )
-  frs_network_upstream(blue_line_key = 360873822, downstream_route_measure = 166030)
+  frs_network_upstream("mock", blue_line_key = 360873822, downstream_route_measure = 166030)
 })
 
 test_that("guards are skipped with include_all = TRUE", {
@@ -19,13 +19,13 @@ test_that("guards are skipped with include_all = TRUE", {
     linear_feature_id = 1L, geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_no_match(sql, "edge_type NOT IN")
       expect_no_match(sql, "wscode_ltree <@ '999'")
       mock_result
     }
   )
-  frs_network_upstream(blue_line_key = 360873822, downstream_route_measure = 166030,
+  frs_network_upstream("mock", blue_line_key = 360873822, downstream_route_measure = 166030,
     include_all = TRUE)
 })
 
@@ -34,12 +34,12 @@ test_that("guards are skipped for non-FWA tables", {
     linear_feature_id = 1L, geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_no_match(sql, "edge_type NOT IN")
       mock_result
     }
   )
-  frs_network_upstream(blue_line_key = 360873822, downstream_route_measure = 166030,
+  frs_network_upstream("mock", blue_line_key = 360873822, downstream_route_measure = 166030,
     table = "bcfishpass.streams_co_vw", wscode_col = "wscode",
     localcode_col = "localcode")
 })
@@ -48,10 +48,12 @@ test_that("guards are skipped for non-FWA tables", {
 
 test_that("frs_network_upstream returns sf of upstream segments", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
 
-  upstream <- frs_network_upstream(
+  upstream <- frs_network_upstream(conn,
     blue_line_key = snapped$blue_line_key,
     downstream_route_measure = snapped$downstream_route_measure
   )
@@ -62,11 +64,13 @@ test_that("frs_network_upstream returns sf of upstream segments", {
 
 test_that("include_all = TRUE returns more or equal segments (placeholder/unmapped)", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
   blk <- 360873822
   drm <- 166030
-  with_guards <- frs_network_upstream(blk, drm)
-  without_guards <- frs_network_upstream(blk, drm, include_all = TRUE)
+  with_guards <- frs_network_upstream(conn, blk, drm)
+  without_guards <- frs_network_upstream(conn, blk, drm, include_all = TRUE)
 
   # Without guards may include placeholder (999 wscode) or unmapped segments
   # In practice fwa_upstream() rarely returns these, so counts may be equal

--- a/tests/testthat/test-frs_point_locate.R
+++ b/tests/testthat/test-frs_point_locate.R
@@ -1,12 +1,14 @@
 test_that("frs_point_locate returns sf point geometry", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
   # First snap to get a valid blue_line_key and measure
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
   blk <- snapped$blue_line_key
   measure <- snapped$downstream_route_measure
 
-  pt <- frs_point_locate(
+  pt <- frs_point_locate(conn,
     blue_line_key = blk,
     downstream_route_measure = measure
   )

--- a/tests/testthat/test-frs_point_snap.R
+++ b/tests/testthat/test-frs_point_snap.R
@@ -1,55 +1,55 @@
 # -- input validation (mocked, no DB needed) ----------------------------------
 
 test_that("x must be single numeric", {
-  expect_error(frs_point_snap(x = "a", y = 1), "x must be a single numeric")
-  expect_error(frs_point_snap(x = NULL, y = 1), "x must be a single numeric")
-  expect_error(frs_point_snap(x = NA, y = 1), "x must be a single numeric")
-  expect_error(frs_point_snap(x = c(1, 2), y = 1), "x must be a single numeric")
+  expect_error(frs_point_snap("mock", x = "a", y = 1), "x must be a single numeric")
+  expect_error(frs_point_snap("mock", x = NULL, y = 1), "x must be a single numeric")
+  expect_error(frs_point_snap("mock", x = NA, y = 1), "x must be a single numeric")
+  expect_error(frs_point_snap("mock", x = c(1, 2), y = 1), "x must be a single numeric")
 })
 
 test_that("y must be single numeric", {
-  expect_error(frs_point_snap(x = 1, y = "a"), "y must be a single numeric")
-  expect_error(frs_point_snap(x = 1, y = NA), "y must be a single numeric")
-  expect_error(frs_point_snap(x = 1, y = c(1, 2)), "y must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = "a"), "y must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = NA), "y must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = c(1, 2)), "y must be a single numeric")
 })
 
 test_that("srid must be single numeric", {
-  expect_error(frs_point_snap(x = 1, y = 1, srid = "abc"), "srid must be a single numeric")
-  expect_error(frs_point_snap(x = 1, y = 1, srid = NA), "srid must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, srid = "abc"), "srid must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, srid = NA), "srid must be a single numeric")
 })
 
 test_that("tolerance must be single numeric", {
-  expect_error(frs_point_snap(x = 1, y = 1, tolerance = "abc"), "tolerance must be a single numeric")
-  expect_error(frs_point_snap(x = 1, y = 1, tolerance = NA), "tolerance must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, tolerance = "abc"), "tolerance must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, tolerance = NA), "tolerance must be a single numeric")
 })
 
 test_that("num_features must be single numeric", {
-  expect_error(frs_point_snap(x = 1, y = 1, num_features = "abc"), "num_features must be a single numeric")
-  expect_error(frs_point_snap(x = 1, y = 1, num_features = NA), "num_features must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, num_features = "abc"), "num_features must be a single numeric")
+  expect_error(frs_point_snap("mock", x = 1, y = 1, num_features = NA), "num_features must be a single numeric")
 })
 
 test_that("blue_line_key must be single numeric when provided", {
   expect_error(
-    frs_point_snap(x = 1, y = 1, blue_line_key = "abc"),
+    frs_point_snap("mock", x = 1, y = 1, blue_line_key = "abc"),
     "blue_line_key must be a single numeric"
   )
   expect_error(
-    frs_point_snap(x = 1, y = 1, blue_line_key = NA),
+    frs_point_snap("mock", x = 1, y = 1, blue_line_key = NA),
     "blue_line_key must be a single numeric"
   )
   expect_error(
-    frs_point_snap(x = 1, y = 1, blue_line_key = c(1, 2)),
+    frs_point_snap("mock", x = 1, y = 1, blue_line_key = c(1, 2)),
     "blue_line_key must be a single numeric"
   )
 })
 
 test_that("stream_order_min must be single numeric when provided", {
   expect_error(
-    frs_point_snap(x = 1, y = 1, stream_order_min = "abc"),
+    frs_point_snap("mock", x = 1, y = 1, stream_order_min = "abc"),
     "stream_order_min must be a single numeric"
   )
   expect_error(
-    frs_point_snap(x = 1, y = 1, stream_order_min = NA),
+    frs_point_snap("mock", x = 1, y = 1, stream_order_min = NA),
     "stream_order_min must be a single numeric"
   )
 })
@@ -66,12 +66,12 @@ test_that("default path uses fwa_indexpoint", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "fwa_indexpoint")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5)
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5)
   expect_s3_class(result, "sf")
 })
 
@@ -85,14 +85,14 @@ test_that("blue_line_key triggers KNN path", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "blue_line_key = 360873822")
       expect_match(sql, "ST_LineLocatePoint")
       expect_no_match(sql, "fwa_indexpoint")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5, blue_line_key = 360873822)
   expect_s3_class(result, "sf")
 })
 
@@ -106,13 +106,13 @@ test_that("stream_order_min triggers KNN path with filter", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "stream_order >= 4")
       expect_no_match(sql, "fwa_indexpoint")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5, stream_order_min = 4)
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5, stream_order_min = 4)
   expect_s3_class(result, "sf")
 })
 
@@ -126,14 +126,14 @@ test_that("KNN path includes stream filtering guards", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "localcode_ltree IS NOT NULL")
       expect_match(sql, "wscode_ltree <@ '999'")
       expect_match(sql, "edge_type NOT IN \\(1410, 1425\\)")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5, blue_line_key = 360873822)
   expect_s3_class(result, "sf")
 })
 
@@ -147,13 +147,13 @@ test_that("blue_line_key and stream_order_min combine in KNN", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "blue_line_key = 360873822")
       expect_match(sql, "stream_order >= 3")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5,
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5,
     blue_line_key = 360873822, stream_order_min = 3)
   expect_s3_class(result, "sf")
 })
@@ -168,14 +168,14 @@ test_that("KNN SQL has boundary clamping", {
     geom = sf::st_sfc(sf::st_point(c(1, 1)), crs = 3005)
   )
   local_mocked_bindings(
-    frs_db_query = function(sql, ...) {
+    frs_db_query = function(conn, sql, ...) {
       expect_match(sql, "CEIL.*GREATEST")
       expect_match(sql, "FLOOR.*LEAST")
       expect_match(sql, "upstream_route_measure")
       mock_result
     }
   )
-  result <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+  result <- frs_point_snap("mock", x = -126.5, y = 54.5, blue_line_key = 360873822)
   expect_s3_class(result, "sf")
 })
 
@@ -183,8 +183,10 @@ test_that("KNN SQL has boundary clamping", {
 
 test_that("frs_point_snap returns sf with network position", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5)
   expect_s3_class(snapped, "sf")
   expect_true(nrow(snapped) == 1)
   expect_true("blue_line_key" %in% names(snapped))
@@ -194,16 +196,20 @@ test_that("frs_point_snap returns sf with network position", {
 
 test_that("frs_point_snap returns multiple candidates", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5, num_features = 3)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5, num_features = 3)
   expect_true(nrow(snapped) <= 3)
 })
 
 test_that("blue_line_key snaps to specified stream", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
   # Bulkley River near confluence — without blk hint might snap to tributary
-  snapped <- frs_point_snap(x = -126.5, y = 54.5, blue_line_key = 360873822)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5, blue_line_key = 360873822)
   expect_s3_class(snapped, "sf")
   expect_true(nrow(snapped) == 1)
   expect_equal(snapped$blue_line_key, 360873822L)
@@ -213,17 +219,21 @@ test_that("blue_line_key snaps to specified stream", {
 
 test_that("stream_order_min filters small streams", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
   # Order 4+ near Bulkley should still find the river
-  snapped <- frs_point_snap(x = -126.5, y = 54.5, stream_order_min = 4)
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5, stream_order_min = 4)
   expect_s3_class(snapped, "sf")
   expect_true(nrow(snapped) >= 1)
 })
 
 test_that("blue_line_key + stream_order_min work together", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  snapped <- frs_point_snap(x = -126.5, y = 54.5,
+  snapped <- frs_point_snap(conn, x = -126.5, y = 54.5,
     blue_line_key = 360873822, stream_order_min = 3)
   expect_s3_class(snapped, "sf")
   expect_equal(snapped$blue_line_key, 360873822L)
@@ -231,10 +241,12 @@ test_that("blue_line_key + stream_order_min work together", {
 
 test_that("KNN returns consistent measure with fwa_indexpoint", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
   # Both paths should find the same stream and similar measure
-  default <- frs_point_snap(x = -126.5, y = 54.5)
-  knn <- frs_point_snap(x = -126.5, y = 54.5,
+  default <- frs_point_snap(conn, x = -126.5, y = 54.5)
+  knn <- frs_point_snap(conn, x = -126.5, y = 54.5,
     blue_line_key = default$blue_line_key)
 
   expect_equal(knn$blue_line_key, default$blue_line_key)

--- a/tests/testthat/test-frs_stream_fetch.R
+++ b/tests/testthat/test-frs_stream_fetch.R
@@ -1,7 +1,9 @@
 test_that("frs_stream_fetch returns sf with watershed_group_code filter", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  streams <- frs_stream_fetch(watershed_group_code = "BULK", limit = 5)
+  streams <- frs_stream_fetch(conn, watershed_group_code = "BULK", limit = 5)
   expect_s3_class(streams, "sf")
   expect_true(nrow(streams) > 0)
   expect_true("blue_line_key" %in% names(streams))
@@ -10,8 +12,10 @@ test_that("frs_stream_fetch returns sf with watershed_group_code filter", {
 
 test_that("frs_stream_fetch filters by stream_order_min", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  streams <- frs_stream_fetch(
+  streams <- frs_stream_fetch(conn,
     watershed_group_code = "BULK",
     stream_order_min = 5,
     limit = 10
@@ -23,12 +27,12 @@ test_that("frs_stream_fetch filters by stream_order_min", {
 
 test_that("frs_stream_fetch includes guards by default", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_stream_fetch(watershed_group_code = "BULK", limit = 1)
+  frs_stream_fetch("mock", watershed_group_code = "BULK", limit = 1)
 
   expect_match(sql_sent, "localcode_ltree IS NOT NULL")
   expect_match(sql_sent, "wscode_ltree <@ '999'")
@@ -36,12 +40,12 @@ test_that("frs_stream_fetch includes guards by default", {
 
 test_that("frs_stream_fetch skips guards with include_all = TRUE", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_stream_fetch(watershed_group_code = "BULK", include_all = TRUE, limit = 1)
+  frs_stream_fetch("mock", watershed_group_code = "BULK", include_all = TRUE, limit = 1)
 
   expect_no_match(sql_sent, "edge_type NOT IN")
 })

--- a/tests/testthat/test-frs_waterbody_network.R
+++ b/tests/testthat/test-frs_waterbody_network.R
@@ -1,12 +1,12 @@
 test_that("frs_waterbody_network builds correct upstream SQL", {
   # Mock frs_db_query to capture the SQL
   sql_sent <- NULL
-  mockery::stub(frs_waterbody_network, "frs_db_query", function(sql, ...) {
+  mockery::stub(frs_waterbody_network, "frs_db_query", function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_waterbody_network(
+  frs_waterbody_network("mock",
     blue_line_key = 360873822,
     downstream_route_measure = 166030
   )
@@ -20,12 +20,12 @@ test_that("frs_waterbody_network builds correct upstream SQL", {
 
 test_that("frs_waterbody_network switches to downstream", {
   sql_sent <- NULL
-  mockery::stub(frs_waterbody_network, "frs_db_query", function(sql, ...) {
+  mockery::stub(frs_waterbody_network, "frs_db_query", function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_waterbody_network(
+  frs_waterbody_network("mock",
     blue_line_key = 360873822,
     downstream_route_measure = 166030,
     direction = "downstream"
@@ -37,12 +37,12 @@ test_that("frs_waterbody_network switches to downstream", {
 
 test_that("frs_waterbody_network accepts custom table and cols", {
   sql_sent <- NULL
-  mockery::stub(frs_waterbody_network, "frs_db_query", function(sql, ...) {
+  mockery::stub(frs_waterbody_network, "frs_db_query", function(conn, sql, ...) {
     sql_sent <<- sql
     data.frame()
   })
 
-  frs_waterbody_network(
+  frs_waterbody_network("mock",
     blue_line_key = 360873822,
     downstream_route_measure = 166030,
     table = "whse_basemapping.fwa_wetlands_poly",
@@ -55,7 +55,7 @@ test_that("frs_waterbody_network accepts custom table and cols", {
 
 test_that("frs_waterbody_network rejects invalid direction", {
   expect_error(
-    frs_waterbody_network(360873822, 166030, direction = "sideways"),
+    frs_waterbody_network("mock", 360873822, 166030, direction = "sideways"),
     "arg"
   )
 })

--- a/tests/testthat/test-frs_watershed_at_measure.R
+++ b/tests/testthat/test-frs_watershed_at_measure.R
@@ -1,13 +1,13 @@
 test_that("frs_watershed_at_measure calls fwa_watershedatmeasure", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
       matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0), ncol = 2, byrow = TRUE)
     )), crs = 3005))
   })
 
-  result <- frs_watershed_at_measure(360873822, 208877)
+  result <- frs_watershed_at_measure("mock", 360873822, 208877)
 
   expect_match(sql_sent, "fwa_watershedatmeasure")
   expect_match(sql_sent, "360873822")
@@ -18,7 +18,7 @@ test_that("frs_watershed_at_measure calls fwa_watershedatmeasure", {
 
 test_that("frs_watershed_at_measure with upstream_measure returns difference", {
   call_count <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_count <<- call_count + 1
     # Return progressively smaller polygons
     if (call_count == 1) {
@@ -32,7 +32,7 @@ test_that("frs_watershed_at_measure with upstream_measure returns difference", {
     }
   })
 
-  result <- frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564)
+  result <- frs_watershed_at_measure("mock", 360873822, 208877, upstream_measure = 233564)
 
   expect_equal(call_count, 2)
   expect_s3_class(result, "sf")
@@ -43,7 +43,7 @@ test_that("frs_watershed_at_measure with upstream_measure returns difference", {
 
 test_that("frs_watershed_at_measure errors when upstream <= downstream on same BLK", {
   expect_error(
-    frs_watershed_at_measure(360873822, 233564, upstream_measure = 208877),
+    frs_watershed_at_measure("mock", 360873822, 233564, upstream_measure = 208877),
     "upstream_measure must be greater"
   )
 })
@@ -51,7 +51,7 @@ test_that("frs_watershed_at_measure errors when upstream <= downstream on same B
 test_that("frs_watershed_at_measure with upstream_blk uses different BLK", {
   sqls <- list()
   call_count <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_count <<- call_count + 1
     sqls[[call_count]] <<- sql
     if (call_count == 1) {
@@ -67,7 +67,7 @@ test_that("frs_watershed_at_measure with upstream_blk uses different BLK", {
     }
   })
 
-  result <- frs_watershed_at_measure(360873822, 165115,
+  result <- frs_watershed_at_measure("mock", 360873822, 165115,
     upstream_measure = 838, upstream_blk = 360886221)
 
   expect_equal(call_count, 2)
@@ -80,7 +80,7 @@ test_that("frs_watershed_at_measure with upstream_blk uses different BLK", {
 
 test_that("frs_watershed_at_measure skips measure check for different BLK", {
   call_count <- 0
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     call_count <<- call_count + 1
     if (call_count == 1) {
       sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
@@ -94,46 +94,46 @@ test_that("frs_watershed_at_measure skips measure check for different BLK", {
   })
 
   # upstream_measure < downstream_route_measure but on different BLK — should NOT error
-  result <- frs_watershed_at_measure(360873822, 208877,
+  result <- frs_watershed_at_measure("mock", 360873822, 208877,
     upstream_measure = 838, upstream_blk = 360886221)
   expect_equal(call_count, 2)
   expect_s3_class(result, "sf")
 })
 
 test_that("frs_watershed_at_measure rejects NULL blue_line_key", {
-  expect_error(frs_watershed_at_measure(NULL, 208877), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", NULL, 208877), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects NA blue_line_key", {
-  expect_error(frs_watershed_at_measure(NA, 208877), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", NA, 208877), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects character blue_line_key", {
-  expect_error(frs_watershed_at_measure("abc", 208877), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", "abc", 208877), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects NULL measure", {
-  expect_error(frs_watershed_at_measure(360873822, NULL), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", 360873822, NULL), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects NA measure", {
-  expect_error(frs_watershed_at_measure(360873822, NA), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", 360873822, NA), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects vector blk", {
-  expect_error(frs_watershed_at_measure(c(1, 2), 208877), "single numeric")
+  expect_error(frs_watershed_at_measure("mock", c(1, 2), 208877), "single numeric")
 })
 
 test_that("frs_watershed_at_measure rejects NA upstream_measure", {
   expect_error(
-    frs_watershed_at_measure(360873822, 208877, upstream_measure = NA),
+    frs_watershed_at_measure("mock", 360873822, 208877, upstream_measure = NA),
     "single numeric"
   )
 })
 
 test_that("frs_watershed_at_measure rejects character upstream_blk", {
   expect_error(
-    frs_watershed_at_measure(360873822, 208877, upstream_measure = 233564,
+    frs_watershed_at_measure("mock", 360873822, 208877, upstream_measure = 233564,
       upstream_blk = "abc"),
     "single numeric"
   )
@@ -141,7 +141,7 @@ test_that("frs_watershed_at_measure rejects character upstream_blk", {
 
 test_that("frs_watershed_at_measure upstream_blk without upstream_measure is ignored", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
       matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0), ncol = 2, byrow = TRUE)
@@ -149,7 +149,7 @@ test_that("frs_watershed_at_measure upstream_blk without upstream_measure is ign
   })
 
   # upstream_blk provided but upstream_measure is NULL — should return single ws
-  result <- frs_watershed_at_measure(360873822, 208877, upstream_blk = 360886221)
+  result <- frs_watershed_at_measure("mock", 360873822, 208877, upstream_blk = 360886221)
   expect_s3_class(result, "sf")
   # Only one query (no subtraction)
   expect_match(sql_sent, "360873822")
@@ -157,14 +157,14 @@ test_that("frs_watershed_at_measure upstream_blk without upstream_measure is ign
 
 test_that("frs_watershed_at_measure equal measures on same BLK errors", {
   expect_error(
-    frs_watershed_at_measure(360873822, 208877, upstream_measure = 208877),
+    frs_watershed_at_measure("mock", 360873822, 208877, upstream_measure = 208877),
     "upstream_measure must be greater"
   )
 })
 
 test_that("frs_watershed_at_measure handles negative measure", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
       matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0), ncol = 2, byrow = TRUE)
@@ -172,25 +172,25 @@ test_that("frs_watershed_at_measure handles negative measure", {
   })
 
   # Negative measure — function doesn't validate, passes to fwapg
-  result <- frs_watershed_at_measure(360873822, -100)
+  result <- frs_watershed_at_measure("mock", 360873822, -100)
   expect_match(sql_sent, "-100")
 })
 
 test_that("frs_watershed_at_measure zero measure works", {
   sql_sent <- NULL
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     sql_sent <<- sql
     sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
       matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0), ncol = 2, byrow = TRUE)
     )), crs = 3005))
   })
 
-  result <- frs_watershed_at_measure(360873822, 0)
+  result <- frs_watershed_at_measure("mock", 360873822, 0)
   expect_match(sql_sent, "fwa_watershedatmeasure\\(360873822, 0\\)")
 })
 
 test_that("frs_watershed_at_measure errors when watersheds don't intersect", {
-  local_mocked_bindings(frs_db_query = function(sql, ...) {
+  local_mocked_bindings(frs_db_query = function(conn, sql, ...) {
     if (grepl("111111", sql)) {
       # Downstream — box at (0,0)
       sf::st_sf(geom = sf::st_sfc(sf::st_polygon(list(
@@ -205,7 +205,7 @@ test_that("frs_watershed_at_measure errors when watersheds don't intersect", {
   })
 
   expect_error(
-    frs_watershed_at_measure(111111, 1000,
+    frs_watershed_at_measure("mock", 111111, 1000,
       upstream_measure = 500, upstream_blk = 222222),
     "does not intersect"
   )

--- a/tests/testthat/test-frs_watershed_split.R
+++ b/tests/testthat/test-frs_watershed_split.R
@@ -1,17 +1,17 @@
 # -- frs_watershed_split unit tests --------------------------------------------
 
 test_that("frs_watershed_split validates inputs", {
-  expect_error(frs_watershed_split("not a df"), "points must be a data frame")
+  expect_error(frs_watershed_split("mock", "not a df"), "points must be a data frame")
   expect_error(
-    frs_watershed_split(data.frame(x = 1, y = 2)),
+    frs_watershed_split("mock", data.frame(x = 1, y = 2)),
     "must have 'lon' and 'lat' columns"
   )
   expect_error(
-    frs_watershed_split(data.frame(lon = numeric(0), lat = numeric(0))),
+    frs_watershed_split("mock", data.frame(lon = numeric(0), lat = numeric(0))),
     "points has no rows"
   )
   expect_error(
-    frs_watershed_split(data.frame(lon = 1, lat = 1), aoi = "bad"),
+    frs_watershed_split("mock", data.frame(lon = 1, lat = 1), aoi = "bad"),
     "aoi must be an sf or sfc"
   )
 })
@@ -22,7 +22,7 @@ test_that("frs_watershed_split errors when all snaps fail", {
   })
   pts <- data.frame(lon = c(0, 0), lat = c(0, 0))
   expect_error(
-    suppressMessages(frs_watershed_split(pts)),
+    suppressMessages(frs_watershed_split("mock", pts)),
     "No points could be snapped"
   )
 })
@@ -42,7 +42,7 @@ test_that("frs_watershed_split errors when all watersheds fail", {
   })
   pts <- data.frame(lon = c(-126, -125), lat = c(54, 55))
   expect_error(
-    suppressMessages(frs_watershed_split(pts)),
+    suppressMessages(frs_watershed_split("mock", pts)),
     "No watersheds could be delineated"
   )
 })
@@ -81,7 +81,7 @@ test_that("frs_watershed_split produces sub-basins from mocked data", {
       c(3, 3), c(7, 3), c(7, 7), c(3, 7), c(3, 3)
     ))), crs = 3005)
   )
-  mockery::stub(frs_watershed_split, "frs_watershed_at_measure", function(blk, drm, ...) {
+  mockery::stub(frs_watershed_split, "frs_watershed_at_measure", function(conn, blk, drm, ...) {
     ws_call <<- ws_call + 1L
     if (ws_call == 1L) big_ws else small_ws
   })
@@ -91,7 +91,7 @@ test_that("frs_watershed_split produces sub-basins from mocked data", {
     lat = c(54.19, 54.46),
     site_name = c("Lower", "Upper")
   )
-  result <- suppressMessages(frs_watershed_split(pts))
+  result <- suppressMessages(frs_watershed_split("mock", pts))
 
   expect_s3_class(result, "sf")
   expect_equal(nrow(result), 2L)
@@ -124,7 +124,7 @@ test_that("frs_watershed_split drops sf geometry from input", {
   mockery::stub(frs_watershed_split, "frs_point_snap", function(...) snap_result)
   mockery::stub(frs_watershed_split, "frs_watershed_at_measure", function(...) ws)
 
-  result <- suppressMessages(frs_watershed_split(pts_sf))
+  result <- suppressMessages(frs_watershed_split("mock", pts_sf))
   expect_s3_class(result, "sf")
   expect_equal(nrow(result), 1L)
 })
@@ -145,6 +145,6 @@ test_that("frs_watershed_split transforms to target crs", {
   mockery::stub(frs_watershed_split, "frs_watershed_at_measure", function(...) ws)
 
   pts <- data.frame(lon = -126.5, lat = 54.19)
-  result <- suppressMessages(frs_watershed_split(pts, crs = 3005))
+  result <- suppressMessages(frs_watershed_split("mock", pts, crs = 3005))
   expect_equal(sf::st_crs(result)$epsg, 3005L)
 })

--- a/tests/testthat/test-frs_wetland_fetch.R
+++ b/tests/testthat/test-frs_wetland_fetch.R
@@ -1,7 +1,9 @@
 test_that("frs_wetland_fetch returns sf with watershed_group_code filter", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  wetlands <- frs_wetland_fetch(watershed_group_code = "BULK", limit = 5)
+  wetlands <- frs_wetland_fetch(conn, watershed_group_code = "BULK", limit = 5)
   expect_s3_class(wetlands, "sf")
   expect_true(nrow(wetlands) > 0)
   expect_true("waterbody_key" %in% names(wetlands))
@@ -10,8 +12,10 @@ test_that("frs_wetland_fetch returns sf with watershed_group_code filter", {
 
 test_that("frs_wetland_fetch filters by area_ha_min", {
   skip_if(Sys.getenv("PG_DB_SHARE") == "", "PG_DB_SHARE not set")
+  conn <- frs_db_conn()
+  on.exit(DBI::dbDisconnect(conn))
 
-  wetlands <- frs_wetland_fetch(
+  wetlands <- frs_wetland_fetch(conn,
     watershed_group_code = "BULK",
     area_ha_min = 5,
     limit = 10

--- a/vignettes/fwa-network-query.Rmd
+++ b/vignettes/fwa-network-query.Rmd
@@ -26,14 +26,16 @@ library(fresh)
 library(sf)
 #> Linking to GEOS 3.13.0, GDAL 3.8.5, PROJ 9.5.1; sf_use_s2() is TRUE
 
+conn <- frs_db_conn()
+
 blk <- 360873822
 drm <- 166030.4
 
 # Watershed AOI via frs_watershed_at_measure()
-aoi <- frs_watershed_at_measure(blk, drm)
+aoi <- frs_watershed_at_measure(conn, blk, drm)
 
 # Full upstream network: streams, coho habitat, lakes, wetlands — one call
-result <- frs_network(blk, drm, tables = list(
+result <- frs_network(conn, blk, drm, tables = list(
   streams = "whse_basemapping.fwa_stream_networks_sp",
   co = list(
     table = "bcfishpass.streams_co_vw",

--- a/vignettes/fwa-network-query.Rmd.orig
+++ b/vignettes/fwa-network-query.Rmd.orig
@@ -32,14 +32,16 @@ zooming in to order 4+ coho rearing/spawning habitat from bcfishpass.
 library(fresh)
 library(sf)
 
+conn <- frs_db_conn()
+
 blk <- 360873822
 drm <- 166030.4
 
 # Watershed AOI via frs_watershed_at_measure()
-aoi <- frs_watershed_at_measure(blk, drm)
+aoi <- frs_watershed_at_measure(conn, blk, drm)
 
 # Full upstream network: streams, coho habitat, lakes, wetlands — one call
-result <- frs_network(blk, drm, tables = list(
+result <- frs_network(conn, blk, drm, tables = list(
   streams = "whse_basemapping.fwa_stream_networks_sp",
   co = list(
     table = "bcfishpass.streams_co_vw",

--- a/vignettes/subbasin-query.Rmd
+++ b/vignettes/subbasin-query.Rmd
@@ -35,15 +35,17 @@ library(tmap)
 
 sf_use_s2(FALSE)
 
+conn <- frs_db_conn()
+
 blk <- 360873822
 drm_byman <- 208877     # just upstream of Byman Creek
 drm_ailport <- 233564   # just upstream of Ailport Creek
 
 # Subbasin polygon (downstream watershed minus upstream watershed)
-aoi <- frs_watershed_at_measure(blk, drm_byman, upstream_measure = drm_ailport)
+aoi <- frs_watershed_at_measure(conn, blk, drm_byman, upstream_measure = drm_ailport)
 
 # Network features between the two points
-result <- frs_network(blk, drm_byman, upstream_measure = drm_ailport,
+result <- frs_network(conn, blk, drm_byman, upstream_measure = drm_ailport,
   tables = list(
     streams = "whse_basemapping.fwa_stream_networks_sp",
     co = list(
@@ -69,7 +71,7 @@ env <- sprintf(
   bb["xmin"], bb["ymin"], bb["xmax"], bb["ymax"]
 )
 
-roads <- frs_db_query(sprintf(
+roads <- frs_db_query(conn, sprintf(
   "SELECT transport_line_type_code, geom
    FROM whse_basemapping.transport_line
    WHERE transport_line_type_code IN
@@ -82,7 +84,7 @@ roads <- st_collection_extract(st_intersection(roads, aoi), "LINESTRING")
 highways <- roads[roads$transport_line_type_code %in% c("RF", "RH1", "RH2"), ]
 roads_other <- roads[!roads$transport_line_type_code %in% c("RF", "RH1", "RH2"), ]
 
-fsr <- frs_db_query(sprintf(
+fsr <- frs_db_query(conn, sprintf(
   "SELECT road_section_name, geom
    FROM whse_forest_tenure.ften_road_section_lines_svw
    WHERE life_cycle_status_code = 'ACTIVE'
@@ -91,7 +93,7 @@ fsr <- frs_db_query(sprintf(
 ))
 fsr <- st_collection_extract(st_intersection(fsr, aoi), "LINESTRING")
 
-railway <- frs_db_query(sprintf(
+railway <- frs_db_query(conn, sprintf(
   "SELECT track_name, geom
    FROM whse_basemapping.gba_railway_tracks_sp
    WHERE ST_Intersects(geom, %s)", env
@@ -101,10 +103,10 @@ if (nrow(railway) > 0) {
 }
 
 # Keymap data: BC outline + Bulkley/Morice watershed groups
-bc <- frs_db_query(
+bc <- frs_db_query(conn,
   "SELECT ST_Simplify(geom, 5000) as geom FROM whse_basemapping.fwa_bcboundary"
 )
-wsg <- frs_db_query(
+wsg <- frs_db_query(conn,
   "SELECT watershed_group_code, geom
    FROM whse_basemapping.fwa_watershed_groups_poly
    WHERE watershed_group_code IN ('BULK', 'MORR')"

--- a/vignettes/subbasin-query.Rmd.orig
+++ b/vignettes/subbasin-query.Rmd.orig
@@ -45,15 +45,17 @@ library(tmap)
 
 sf_use_s2(FALSE)
 
+conn <- frs_db_conn()
+
 blk <- 360873822
 drm_byman <- 208877     # just upstream of Byman Creek
 drm_ailport <- 233564   # just upstream of Ailport Creek
 
 # Subbasin polygon (downstream watershed minus upstream watershed)
-aoi <- frs_watershed_at_measure(blk, drm_byman, upstream_measure = drm_ailport)
+aoi <- frs_watershed_at_measure(conn, blk, drm_byman, upstream_measure = drm_ailport)
 
 # Network features between the two points
-result <- frs_network(blk, drm_byman, upstream_measure = drm_ailport,
+result <- frs_network(conn, blk, drm_byman, upstream_measure = drm_ailport,
   tables = list(
     streams = "whse_basemapping.fwa_stream_networks_sp",
     co = list(
@@ -79,7 +81,7 @@ env <- sprintf(
   bb["xmin"], bb["ymin"], bb["xmax"], bb["ymax"]
 )
 
-roads <- frs_db_query(sprintf(
+roads <- frs_db_query(conn, sprintf(
   "SELECT transport_line_type_code, geom
    FROM whse_basemapping.transport_line
    WHERE transport_line_type_code IN
@@ -92,7 +94,7 @@ roads <- st_collection_extract(st_intersection(roads, aoi), "LINESTRING")
 highways <- roads[roads$transport_line_type_code %in% c("RF", "RH1", "RH2"), ]
 roads_other <- roads[!roads$transport_line_type_code %in% c("RF", "RH1", "RH2"), ]
 
-fsr <- frs_db_query(sprintf(
+fsr <- frs_db_query(conn, sprintf(
   "SELECT road_section_name, geom
    FROM whse_forest_tenure.ften_road_section_lines_svw
    WHERE life_cycle_status_code = 'ACTIVE'
@@ -101,7 +103,7 @@ fsr <- frs_db_query(sprintf(
 ))
 fsr <- st_collection_extract(st_intersection(fsr, aoi), "LINESTRING")
 
-railway <- frs_db_query(sprintf(
+railway <- frs_db_query(conn, sprintf(
   "SELECT track_name, geom
    FROM whse_basemapping.gba_railway_tracks_sp
    WHERE ST_Intersects(geom, %s)", env
@@ -111,10 +113,10 @@ if (nrow(railway) > 0) {
 }
 
 # Keymap data: BC outline + Bulkley/Morice watershed groups
-bc <- frs_db_query(
+bc <- frs_db_query(conn,
   "SELECT ST_Simplify(geom, 5000) as geom FROM whse_basemapping.fwa_bcboundary"
 )
-wsg <- frs_db_query(
+wsg <- frs_db_query(conn,
   "SELECT watershed_group_code, geom
    FROM whse_basemapping.fwa_watershed_groups_poly
    WHERE watershed_group_code IN ('BULK', 'MORR')"


### PR DESCRIPTION
## Summary

- All DB-using functions now take `conn` as first required parameter instead of `...`
- `frs_db_query(conn, query)` replaces `frs_db_query(query, ...)`  
- Enables `conn |> frs_break() |> frs_classify()` piping for upcoming habitat model functions
- `frs_watershed_at_measure()` validation moved before DB call (fail-fast)
- All 322 tests pass, vignettes updated

## Breaking change

Every `frs_*()` call that previously passed connection args via `...` now needs:

```r
conn <- frs_db_conn()
frs_stream_fetch(conn, watershed_group_code = "BULK")
DBI::dbDisconnect(conn)
```

## Test plan

- [x] All 322 unit + integration tests pass
- [x] Live DB integration verified (stream_fetch, point_snap, watershed_at_measure, network, params)
- [x] R CMD check: 0 errors
- [ ] Install branch in restoration report, verify builds
- [ ] Install branch in neexdzii benthic report, verify builds
- [ ] Install branch in breaks app, verify runs

```r
pak::pak("NewGraphEnvironment/fresh@35-conn-first")
```

Relates to NewGraphEnvironment/sred-2025-2026#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
