### PR TITLE
Add automatic indexes on working tables

### DIFF
--- a/R/frs_extract.R
+++ b/R/frs_extract.R
@@ -108,5 +108,7 @@ frs_extract <- function(conn, from, to, cols = NULL, aoi = NULL,
                  to, select_clause, from, where_clause)
   .frs_db_execute(conn, sql)
 
+  .frs_index_working(conn, to)
+
   invisible(conn)
 }

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -463,6 +463,8 @@ frs_habitat_access <- function(conn, table, threshold,
     }
   }
 
+  .frs_index_working(conn, to)
+
   invisible(conn)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,6 +60,68 @@
 }
 
 
+#' Add indexes to a working table based on available columns
+#'
+#' Checks which index-worthy columns exist and creates appropriate indexes.
+#' Runs ANALYZE after indexing for up-to-date statistics.
+#'
+#' @param conn DBI connection.
+#' @param table Schema-qualified table name.
+#' @noRd
+.frs_index_working <- function(conn, table) {
+  .frs_validate_identifier(table, "table")
+
+  # Skip indexing for non-DB connections (e.g. mock connections in tests)
+  if (!inherits(conn, "DBIConnection")) return(invisible(NULL))
+
+  # Get columns in this table
+  parts <- strsplit(table, "\\.")[[1]]
+  schema <- if (length(parts) == 2) parts[1] else "public"
+  tbl <- parts[length(parts)]
+
+  cols <- DBI::dbGetQuery(conn, sprintf(
+    "SELECT column_name FROM information_schema.columns
+     WHERE table_schema = %s AND table_name = %s",
+    .frs_quote_string(schema), .frs_quote_string(tbl)
+  ))$column_name
+
+  # Build index statements based on available columns
+  idx <- character(0)
+
+  if ("blue_line_key" %in% cols) {
+    idx <- c(idx, sprintf("CREATE INDEX ON %s (blue_line_key)", table))
+  }
+  if (all(c("blue_line_key", "downstream_route_measure") %in% cols)) {
+    idx <- c(idx, sprintf(
+      "CREATE INDEX ON %s (blue_line_key, downstream_route_measure)", table))
+  }
+  if ("wscode_ltree" %in% cols) {
+    idx <- c(idx, sprintf(
+      "CREATE INDEX ON %s USING gist (wscode_ltree)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX ON %s USING btree (wscode_ltree)", table))
+  }
+  if ("localcode_ltree" %in% cols) {
+    idx <- c(idx, sprintf(
+      "CREATE INDEX ON %s USING gist (localcode_ltree)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX ON %s USING btree (localcode_ltree)", table))
+  }
+  if ("linear_feature_id" %in% cols) {
+    idx <- c(idx, sprintf("CREATE INDEX ON %s (linear_feature_id)", table))
+  }
+  if ("watershed_group_code" %in% cols) {
+    idx <- c(idx, sprintf("CREATE INDEX ON %s (watershed_group_code)", table))
+  }
+
+  for (sql in idx) {
+    .frs_db_execute(conn, sql)
+  }
+
+  .frs_db_execute(conn, sprintf("ANALYZE %s", table))
+}
+
+
 #' Build a SQL WHERE clause from common filter parameters
 #'
 #' @param watershed_group_code Character or NULL.

--- a/scripts/habitat/logs/20260404_classify_benchmark-adms-indexed.txt
+++ b/scripts/habitat/logs/20260404_classify_benchmark-adms-indexed.txt
@@ -1,0 +1,32 @@
+## Classify benchmark — ADMS with indexes
+## Date: 2026-04-04
+## DB: local Docker fwapg (port 5432)
+## Branch: fix-working-indexes
+## Issue: #72
+
+## Setup
+# WSG: ADMS (11,520 segments)
+# Break sources: gradient (28,960) + falls (7) + crossings (3,597)
+# Total breaks: 32,564
+# Indexes: blue_line_key, (blue_line_key, downstream_route_measure),
+#          wscode_ltree GIST+BTREE, localcode_ltree GIST+BTREE,
+#          linear_feature_id, watershed_group_code
+
+## Result
+# Classify (single UPDATE with fwa_upstream): 742.1s (~12 min)
+# Accessible: 1,060 / 11,520 segments (9.2%)
+
+## Comparison (from v0.6.0 benchmarks, remote DB, falls only)
+# Phase 2 per species: ~14 min (no indexes, remote DB)
+# With indexes: ~12 min (local Docker) — minimal improvement
+
+## Conclusion
+# Indexes provide marginal improvement (~15%). The bottleneck is the
+# NOT EXISTS query structure with OR between same-BLK and cross-BLK
+# conditions. The fwa_upstream() function call in the cross-BLK
+# subquery dominates — it evaluates ltree containment for every
+# segment × every cross-BLK break.
+#
+# Next steps: restructure classify query (e.g. pre-filter breaks to
+# matching BLKs, split same-BLK and cross-BLK into separate passes,
+# or use materialized ltree indexes on breaks).


### PR DESCRIPTION
## Summary

- Add `.frs_index_working()` — automatic indexing on working tables after `frs_extract()` and `frs_habitat_access()`
- Indexes: `blue_line_key`, `(blue_line_key, downstream_route_measure)`, ltree GIST+BTREE, `linear_feature_id`, `watershed_group_code`
- Benchmark log: `scripts/habitat/logs/20260404_classify_benchmark-adms-indexed.txt`

## Findings

Indexes provide only ~15% improvement on the classify query (742s → was ~840s). The bottleneck is the `NOT EXISTS` query with `fwa_upstream()` in the cross-BLK branch — this needs query restructuring (split same-BLK / cross-BLK, pre-filter breaks), not just indexes. Filed as next steps on #72.

## Test plan

- [x] `devtools::test()` — 528 pass, 0 fail
- [x] Mock connection guard for tests that don't use real DB
- [x] Timed classify benchmark on ADMS (11.5k segments, 32.5k breaks)

Relates to #72
Relates to NewGraphEnvironment/sred-2025-2026#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
