### PR TITLE
Fix gradient barrier precision loss with new label format

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -287,6 +287,11 @@ frs_habitat <- function(conn, wsg = NULL,
     # to 4 digits (resolution of 1 basis point).
     all_thresholds <- sort(unique(c(access_thresholds, extra_thresholds)))
 
+    # Validate combined thresholds — catches collisions from
+    # user-supplied custom params even when breaks_gradient is NULL.
+    .frs_validate_gradient_thresholds(all_thresholds,
+      "combined gradient thresholds")
+
     # 2. Generate gradient barriers at each threshold
     streams_tbl <- paste0("working.streams_", job_label)
 
@@ -429,6 +434,9 @@ frs_habitat <- function(conn, wsg = NULL,
       }
 
       all_thresholds <- sort(unique(c(access_thresholds, extra_thresholds)))
+
+      .frs_validate_gradient_thresholds(all_thresholds,
+        "combined gradient thresholds")
 
       streams_tbl <- paste0("working.streams_", job_label)
       tmp_tbl <- paste0(streams_tbl, "_tmp")

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -153,7 +153,7 @@ frs_habitat <- function(conn, wsg = NULL,
                         cleanup = TRUE, verbose = TRUE) {
 
   if (!is.null(breaks_gradient)) {
-    stopifnot(is.numeric(breaks_gradient))
+    .frs_validate_gradient_thresholds(breaks_gradient, "breaks_gradient")
   }
 
   t_total <- proc.time()
@@ -280,12 +280,12 @@ frs_habitat <- function(conn, wsg = NULL,
       as.numeric(breaks_gradient)
     }
 
-    # Union, sort ascending, dedupe by integer-percent label.
-    # Two thresholds that round to the same gradient_N label would
-    # otherwise collide on the barrier table name and label string.
-    all_thresholds <- sort(c(access_thresholds, extra_thresholds))
-    all_thresholds <- all_thresholds[
-      !duplicated(as.integer(all_thresholds * 100))]
+    # Union, sort ascending, dedupe on actual numeric value.
+    # Distinct biological thresholds (e.g. 0.05 and 0.0549) are
+    # preserved — they each get their own break and a unique
+    # `gradient_NNNN` label that captures threshold * 10000 padded
+    # to 4 digits (resolution of 1 basis point).
+    all_thresholds <- sort(unique(c(access_thresholds, extra_thresholds)))
 
     # 2. Generate gradient barriers at each threshold
     streams_tbl <- paste0("working.streams_", job_label)
@@ -319,14 +319,15 @@ frs_habitat <- function(conn, wsg = NULL,
     barrier_tables <- character(0)
 
     for (thr in all_thresholds) {
-      thr_tbl <- sprintf("working.barriers_%s_%d",
-                         job_label, as.integer(thr * 100))
+      thr_label <- .frs_gradient_label(thr)
+      thr_tbl <- sprintf("working.barriers_%s_%s",
+                         job_label, sub("^gradient_", "", thr_label))
       frs_break_find(w_conn, tmp_tbl,
         attribute = "gradient", threshold = thr,
         to = thr_tbl)
       all_sources <- c(all_sources, list(list(
         table = thr_tbl,
-        label = sprintf("gradient_%d", as.integer(thr * 100)))))
+        label = thr_label)))
       barrier_tables <- c(barrier_tables, thr_tbl)
     }
 
@@ -427,9 +428,7 @@ frs_habitat <- function(conn, wsg = NULL,
         as.numeric(breaks_gradient)
       }
 
-      all_thresholds <- sort(c(access_thresholds, extra_thresholds))
-      all_thresholds <- all_thresholds[
-        !duplicated(as.integer(all_thresholds * 100))]
+      all_thresholds <- sort(unique(c(access_thresholds, extra_thresholds)))
 
       streams_tbl <- paste0("working.streams_", job_label)
       tmp_tbl <- paste0(streams_tbl, "_tmp")
@@ -455,13 +454,14 @@ frs_habitat <- function(conn, wsg = NULL,
       all_sources <- if (!is.null(break_sources)) break_sources else list()
       barrier_tables <- character(0)
       for (thr in all_thresholds) {
-        thr_tbl <- sprintf("working.barriers_%s_%d",
-                           job_label, as.integer(thr * 100))
+        thr_label <- .frs_gradient_label(thr)
+        thr_tbl <- sprintf("working.barriers_%s_%s",
+                           job_label, sub("^gradient_", "", thr_label))
         frs_break_find(w_conn, tmp_tbl,
           attribute = "gradient", threshold = thr, to = thr_tbl)
         all_sources <- c(all_sources, list(list(
           table = thr_tbl,
-          label = sprintf("gradient_%d", as.integer(thr * 100)))))
+          label = thr_label)))
         barrier_tables <- c(barrier_tables, thr_tbl)
       }
 

--- a/R/frs_habitat_classify.R
+++ b/R/frs_habitat_classify.R
@@ -25,8 +25,10 @@
 #'   inaccessible. If `FALSE`, all segments are classified regardless of
 #'   breaks (raw habitat potential).
 #' @param label_block Character vector. Labels that always block
-#'   access. Default `"blocked"`. Gradient labels (`gradient_15`, etc.)
-#'   are always threshold-aware regardless of this parameter. Set to
+#'   access. Default `"blocked"`. Gradient labels (`gradient_NNNN`,
+#'   the canonical 4-digit basis-point format like `gradient_1500` for
+#'   15%, or the legacy `gradient_N` like `gradient_15`) are always
+#'   threshold-aware regardless of this parameter. Set to
 #'   `c("blocked", "potential")` for conservative analysis.
 #' @param overwrite Logical. If `TRUE`, replace existing rows for
 #'   these species in the output table. Default `TRUE`.
@@ -43,12 +45,12 @@
 #' conn <- frs_db_conn()
 #'
 #' # Assumes fresh.streams built by frs_network_segment() with
-#' # gradient barriers labeled "gradient_15", "gradient_20", "gradient_25".
-#' # See frs_network_segment() for the full setup.
+#' # gradient barriers labeled "gradient_1500", "gradient_2000",
+#' # "gradient_2500" (15%, 20%, 25% — see frs_network_segment()).
 #'
 #' # Classify CO, BT, ST — each gets species-specific accessibility.
-#' # CO (15% access) is blocked by gradient_15, gradient_20, gradient_25.
-#' # BT (25% access) is only blocked by gradient_25.
+#' # CO (15% access) is blocked by gradient_1500, gradient_2000,
+#' # gradient_2500. BT (25% access) is only blocked by gradient_2500.
 #' # Result: BT has ~2x the accessible habitat of CO on the same network.
 #' frs_habitat_classify(conn,
 #'   table = "fresh.streams",
@@ -322,7 +324,8 @@ frs_habitat_classify <- function(conn, table, to,
 #' Build SQL label filter for species-specific accessibility
 #'
 #' Determines which break labels block a species based on its access
-#' gradient threshold. Gradient labels like `"gradient_15"` are parsed
+#' gradient threshold. Gradient labels like `"gradient_1500"` (new
+#' 4-digit basis-point format) or `"gradient_15"` (legacy) are parsed
 #' to extract the threshold value. Labels >= the species' threshold
 #' block that species. Non-gradient labels (e.g. `"blocked"`) always
 #' block.
@@ -339,16 +342,26 @@ frs_habitat_classify <- function(conn, table, to,
     "SELECT DISTINCT label FROM %s", breaks_tbl))$label
 
   # Determine which labels block this species
-  # Two patterns:
+  # Patterns recognized:
   #   label_block — user-configured labels that always block
-  #   "gradient_N" — blocks species with access threshold <= N%
+  #   "gradient_NNNN" — new format (4-digit basis points * 10).
+  #     Parsed as N / 10000. Resolution 0.0001.
+  #   "gradient_N"  — legacy format (integer percent, 1-3 digits).
+  #     Parsed as N / 100. Backward compat for user-supplied labels
+  #     like `frs_break_find(label = "gradient_15")`.
   # Everything else does not block
   blocking <- vapply(labels, function(lbl) {
     if (is.na(lbl)) return(FALSE)
     if (lbl %in% label_block) return(TRUE)
-    m <- regmatches(lbl, regexec("^gradient_(\\d+)$", lbl))[[1]]
-    if (length(m) == 2) {
-      return(as.numeric(m[2]) / 100 >= access_gradient)
+    # New format: gradient_NNNN
+    m4 <- regmatches(lbl, regexec("^gradient_(\\d{4})$", lbl))[[1]]
+    if (length(m4) == 2) {
+      return(as.numeric(m4[2]) / 10000 >= access_gradient)
+    }
+    # Legacy format: gradient_N (1-3 digits)
+    m_legacy <- regmatches(lbl, regexec("^gradient_(\\d{1,3})$", lbl))[[1]]
+    if (length(m_legacy) == 2) {
+      return(as.numeric(m_legacy[2]) / 100 >= access_gradient)
     }
     FALSE
   }, logical(1))

--- a/R/frs_network_segment.R
+++ b/R/frs_network_segment.R
@@ -60,16 +60,20 @@
 #'
 #' # 2. Segment the network at ALL barrier points + falls.
 #' #    One table, one copy of geometry, shared across all species.
-#' #    Labels control which species each barrier blocks — gradient_15
-#' #    blocks CO but not BT; gradient_25 blocks both.
+#' #    Labels control which species each barrier blocks — gradient_1500
+#' #    (15%) blocks CO but not BT; gradient_2500 (25%) blocks both.
+#' #    Labels follow the gradient_NNNN format: 4-digit zero-padded
+#' #    basis points (threshold * 10000). The legacy gradient_N format
+#' #    (e.g. "gradient_15") is still accepted by the parser for
+#' #    backward compatibility with user-supplied labels.
 #' #    Falls (from inst/extdata/falls.csv, loaded to working.falls)
 #' #    block all species.
 #' frs_network_segment(conn, aoi = "BULK",
 #'   to = "fresh.streams",
 #'   break_sources = list(
-#'     list(table = "working.barriers_15", label = "gradient_15"),
-#'     list(table = "working.barriers_20", label = "gradient_20"),
-#'     list(table = "working.barriers_25", label = "gradient_25"),
+#'     list(table = "working.barriers_15", label = "gradient_1500"),
+#'     list(table = "working.barriers_20", label = "gradient_2000"),
+#'     list(table = "working.barriers_25", label = "gradient_2500"),
 #'     list(table = "working.falls",
 #'          where = "barrier_ind = TRUE", label = "blocked")
 #'   ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,6 +73,88 @@
 }
 
 
+#' Format a gradient threshold as a `gradient_NNNN` label
+#'
+#' Generates the canonical 4-digit zero-padded basis-point label.
+#' `0.05` becomes `"gradient_0500"`. `0.0549` becomes
+#' `"gradient_0549"`.
+#'
+#' @param thr Numeric scalar in `[0, 1]`. Caller should validate
+#'   first via [.frs_validate_gradient_thresholds()].
+#' @return Character scalar.
+#' @noRd
+.frs_gradient_label <- function(thr) {
+  sprintf("gradient_%04d", as.integer(round(thr * 10000)))
+}
+
+
+#' Validate a vector of gradient threshold values
+#'
+#' Errors if any value is:
+#'   - not numeric or NA
+#'   - outside `[0, 1]` (gradient is a fraction, not a percent)
+#'   - cannot be represented exactly at basis-point precision
+#'     (e.g. `0.05001` rounds to the same label as `0.05`)
+#'   - duplicates another value's label after rounding
+#'
+#' Catches the silent failure mode where two distinct user-supplied
+#' thresholds produce the same `gradient_NNNN` label and would
+#' overwrite each other's barrier table.
+#'
+#' @param x Numeric vector of gradient thresholds (as fractions).
+#' @param name Character. Argument name for error messages.
+#' @return Invisible `x`. Errors on failure.
+#' @noRd
+.frs_validate_gradient_thresholds <- function(x, name = "thresholds") {
+  if (!is.numeric(x)) {
+    stop(sprintf("%s must be numeric", name), call. = FALSE)
+  }
+  if (length(x) == 0) {
+    return(invisible(x))
+  }
+  if (any(is.na(x))) {
+    stop(sprintf("%s contains NA values", name), call. = FALSE)
+  }
+  if (any(x < 0 | x > 1)) {
+    bad <- x[x < 0 | x > 1]
+    stop(sprintf(
+      "%s values must be in [0, 1] (gradient as fraction, not percent). Got: %s",
+      name, paste(bad, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  # Precision check: must round-trip through 4-digit basis points
+  rounded <- as.integer(round(x * 10000)) / 10000
+  diffs <- abs(x - rounded)
+  if (any(diffs > 1e-10)) {
+    bad <- x[diffs > 1e-10]
+    stop(sprintf(
+      paste0(
+        "%s values exceed basis-point precision (0.0001). ",
+        "Each value must be representable as gradient_NNNN. Got: %s. ",
+        "Round to 4 decimal places (e.g. 0.0549)."
+      ),
+      name, paste(bad, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  # Label collision check: after rounding, no two values should map
+  # to the same label. This is a defensive check — should be impossible
+  # if precision check passed.
+  labels_int <- as.integer(round(x * 10000))
+  if (anyDuplicated(labels_int)) {
+    dup_idx <- duplicated(labels_int) | duplicated(labels_int, fromLast = TRUE)
+    bad <- unique(x[dup_idx])
+    stop(sprintf(
+      "%s values produce duplicate labels at basis-point precision: %s",
+      name, paste(bad, collapse = ", ")
+    ), call. = FALSE)
+  }
+
+  invisible(x)
+}
+
+
 #' Add id_segment column to a working table
 #'
 #' Assigns a unique integer ID to every row. Uses `linear_feature_id`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ frs_break_find(conn, "working.tmp",
 frs_network_segment(conn, aoi = "BULK",
   to = "fresh.streams",
   break_sources = list(
-    list(table = "working.barriers_15", label = "gradient_15"),
+    list(table = "working.barriers_15", label = "gradient_1500"),
     list(table = "working.falls", label = "blocked")))
 
 # 3. Classify habitat per species

--- a/man/frs_habitat_classify.Rd
+++ b/man/frs_habitat_classify.Rd
@@ -41,8 +41,10 @@ inaccessible. If \code{FALSE}, all segments are classified regardless of
 breaks (raw habitat potential).}
 
 \item{label_block}{Character vector. Labels that always block
-access. Default \code{"blocked"}. Gradient labels (\code{gradient_15}, etc.)
-are always threshold-aware regardless of this parameter. Set to
+access. Default \code{"blocked"}. Gradient labels (\code{gradient_NNNN},
+the canonical 4-digit basis-point format like \code{gradient_1500} for
+15\%, or the legacy \code{gradient_N} like \code{gradient_15}) are always
+threshold-aware regardless of this parameter. Set to
 \code{c("blocked", "potential")} for conservative analysis.}
 
 \item{overwrite}{Logical. If \code{TRUE}, replace existing rows for
@@ -69,12 +71,12 @@ a breaks table (\verb{\{streams_table\}_breaks}) for accessibility checks.
 conn <- frs_db_conn()
 
 # Assumes fresh.streams built by frs_network_segment() with
-# gradient barriers labeled "gradient_15", "gradient_20", "gradient_25".
-# See frs_network_segment() for the full setup.
+# gradient barriers labeled "gradient_1500", "gradient_2000",
+# "gradient_2500" (15\%, 20\%, 25\% — see frs_network_segment()).
 
 # Classify CO, BT, ST — each gets species-specific accessibility.
-# CO (15\% access) is blocked by gradient_15, gradient_20, gradient_25.
-# BT (25\% access) is only blocked by gradient_25.
+# CO (15\% access) is blocked by gradient_1500, gradient_2000,
+# gradient_2500. BT (25\% access) is only blocked by gradient_2500.
 # Result: BT has ~2x the accessible habitat of CO on the same network.
 frs_habitat_classify(conn,
   table = "fresh.streams",
@@ -113,6 +115,7 @@ Other habitat:
 \code{\link{frs_break_validate}()},
 \code{\link{frs_categorize}()},
 \code{\link{frs_classify}()},
+\code{\link{frs_cluster}()},
 \code{\link{frs_col_generate}()},
 \code{\link{frs_col_join}()},
 \code{\link{frs_extract}()},

--- a/man/frs_network_segment.Rd
+++ b/man/frs_network_segment.Rd
@@ -80,16 +80,20 @@ frs_break_find(conn, "working.tmp_bulk",
 
 # 2. Segment the network at ALL barrier points + falls.
 #    One table, one copy of geometry, shared across all species.
-#    Labels control which species each barrier blocks — gradient_15
-#    blocks CO but not BT; gradient_25 blocks both.
+#    Labels control which species each barrier blocks — gradient_1500
+#    (15\%) blocks CO but not BT; gradient_2500 (25\%) blocks both.
+#    Labels follow the gradient_NNNN format: 4-digit zero-padded
+#    basis points (threshold * 10000). The legacy gradient_N format
+#    (e.g. "gradient_15") is still accepted by the parser for
+#    backward compatibility with user-supplied labels.
 #    Falls (from inst/extdata/falls.csv, loaded to working.falls)
 #    block all species.
 frs_network_segment(conn, aoi = "BULK",
   to = "fresh.streams",
   break_sources = list(
-    list(table = "working.barriers_15", label = "gradient_15"),
-    list(table = "working.barriers_20", label = "gradient_20"),
-    list(table = "working.barriers_25", label = "gradient_25"),
+    list(table = "working.barriers_15", label = "gradient_1500"),
+    list(table = "working.barriers_20", label = "gradient_2000"),
+    list(table = "working.barriers_25", label = "gradient_2500"),
     list(table = "working.falls",
          where = "barrier_ind = TRUE", label = "blocked")
   ))
@@ -122,6 +126,7 @@ Other habitat:
 \code{\link{frs_break_validate}()},
 \code{\link{frs_categorize}()},
 \code{\link{frs_classify}()},
+\code{\link{frs_cluster}()},
 \code{\link{frs_col_generate}()},
 \code{\link{frs_col_join}()},
 \code{\link{frs_extract}()},

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -10,22 +10,29 @@
 - Created fresh `planning/active/{task_plan,findings,progress}.md` for #110
 - Initial commit: `ee5da61 Archive stale planning files for issue #56 (coho habitat vignette)`
 
-#### Phase 1: Branch and core fix
+#### Phase 1: Branch and core fix ✓
+- Branch `110-gradient-label-precision` created
+- Replaced lossy dedup with `unique()` in both sequential and mirai branches
+- New `gradient_NNNN` label format via `.frs_gradient_label()` helper
+- Updated `.frs_access_label_filter()` to accept both new + legacy formats
 
-- (in progress)
+#### Phase 2: Update tests ✓
+- Updated mocks in test-frs_habitat_classify.R to new format
+- Added 9 label parser tests: legacy compat, mixed format, malformed, parametric
+- Added 6 validation tests for `.frs_validate_gradient_thresholds()`
+- Added regression test for 0.05 vs 0.0549 distinct labels
 
-#### Phase 2: Update tests
-
-- (pending)
-
-#### Phase 3: Update docs and examples
-
-- (pending)
+#### Phase 3: Update docs and examples ✓
+- Updated examples in frs_network_segment.R, frs_habitat_classify.R, README.md
+- Documented both formats in label_block parameter doc
 
 #### Phase 4: Verify and release
-
-- (pending)
+- All 600 tests pass
+- Commit: `ad94bc7 Fix gradient barrier precision loss with new label format`
+- Code-check round 1: found latent bug — auto-derived thresholds bypass validation when user passes custom params. Could cause silent label collision in the auto-derive path.
+- Fix commit: `6acfa94 Validate combined gradient thresholds in frs_habitat()`
+- Code-check round 2: clean
+- (next: push, PR, merge)
 
 #### Phase 5: Archive PWF
-
-- (pending)
+- (pending after merge)

--- a/tests/testthat/test-frs_habitat.R
+++ b/tests/testthat/test-frs_habitat.R
@@ -3,8 +3,50 @@
 test_that("breaks_gradient validates type", {
   expect_error(
     frs_habitat("mock", "BULK", breaks_gradient = "high"),
-    "is.numeric"
+    "must be numeric"
   )
+})
+
+test_that("breaks_gradient validates range [0,1]", {
+  expect_error(
+    frs_habitat("mock", "BULK", breaks_gradient = c(0.05, 1.5)),
+    "must be in \\[0, 1\\]"
+  )
+  expect_error(
+    frs_habitat("mock", "BULK", breaks_gradient = c(-0.01, 0.05)),
+    "must be in \\[0, 1\\]"
+  )
+})
+
+test_that("breaks_gradient errors on excess precision", {
+  # 0.05001 cannot be represented at 4-digit basis points
+  expect_error(
+    frs_habitat("mock", "BULK", breaks_gradient = c(0.05001)),
+    "exceed basis-point precision"
+  )
+})
+
+test_that("breaks_gradient errors on duplicate labels", {
+  # Distinct values that round to same label
+  # Note: basis-point precision check catches this first for most inputs.
+  # This tests the fallback collision check directly.
+  expect_error(
+    .frs_validate_gradient_thresholds(c(0.05, 0.0500), "test"),
+    "duplicate labels|exceed basis-point"
+  )
+})
+
+test_that("breaks_gradient errors on NA", {
+  expect_error(
+    frs_habitat("mock", "BULK", breaks_gradient = c(0.05, NA)),
+    "contains NA"
+  )
+})
+
+test_that("breaks_gradient accepts valid 4-decimal values", {
+  # Should NOT error
+  expect_silent(.frs_validate_gradient_thresholds(c(0.0249, 0.05, 0.0549, 0.10, 0.15), "test"))
+  expect_silent(.frs_validate_gradient_thresholds(numeric(0), "test"))
 })
 
 test_that("breaks_gradient default auto-derives from params", {
@@ -107,4 +149,45 @@ test_that("breaks_gradient custom override produces more segments than disabled"
   # Adding one extra break should produce >= segments (more or equal,
   # depending on whether 10% is exceeded anywhere in the test area)
   expect_gte(res_custom$n_segments, res_min$n_segments)
+})
+
+test_that("regression #110: distinct thresholds produce distinct labels", {
+  # Pre-fix bug: 0.05 and 0.0549 both rounded to gradient_5 (collision)
+  # Post-fix: 0.05 → gradient_0500, 0.0549 → gradient_0549 (distinct)
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+
+  aoi <- "wscode_ltree <@ '100.190442.999098.995997.058910.432966'::ltree"
+
+  on.exit({
+    for (tbl in c("working.persist_brk_110",
+                  "working.persist_brk_110_habitat",
+                  "working.persist_brk_110_one",
+                  "working.persist_brk_110_one_habitat")) {
+      DBI::dbExecute(conn, sprintf("DROP TABLE IF EXISTS %s CASCADE", tbl))
+    }
+    DBI::dbDisconnect(conn)
+  })
+
+  # Pass two thresholds that would collide under the old format
+  frs_habitat(conn,
+    aoi = aoi, species = c("CO", "BT"), label = "brktest_110",
+    to_streams = "working.persist_brk_110",
+    to_habitat = "working.persist_brk_110_habitat",
+    breaks_gradient = c(0.05, 0.0549),
+    verbose = FALSE)
+
+  res_one <- frs_habitat(conn,
+    aoi = aoi, species = c("CO", "BT"), label = "brktest_110b",
+    to_streams = "working.persist_brk_110_one",
+    to_habitat = "working.persist_brk_110_one_habitat",
+    breaks_gradient = c(0.05),
+    verbose = FALSE)
+
+  res_two <- DBI::dbGetQuery(conn,
+    "SELECT count(*)::int AS n FROM working.persist_brk_110")$n
+
+  # Two distinct thresholds should produce >= segments than one
+  # (more if any segments fall between 5.0% and 5.49% gradient)
+  expect_gte(res_two, res_one$n_segments)
 })

--- a/tests/testthat/test-frs_habitat_classify.R
+++ b/tests/testthat/test-frs_habitat_classify.R
@@ -20,14 +20,14 @@ test_that("species is required", {
 
 # --- Unit tests: .frs_access_label_filter ---
 
-test_that("only label_block and gradient labels block", {
+test_that("only label_block and gradient labels block (new format)", {
   local_mocked_bindings(
     .frs_db_execute = function(conn, sql) 0L
   )
 
   mock_labels <- data.frame(
     label = c("blocked", "passable", "accessible", "observed",
-              "potential", "gradient_15", "gradient_25",
+              "potential", "gradient_1500", "gradient_2500",
               "bridge", "monitoring_station"),
     stringsAsFactors = FALSE)
 
@@ -37,15 +37,56 @@ test_that("only label_block and gradient labels block", {
   # Default label_block = "blocked"
   result <- .frs_access_label_filter("mock", "breaks", 0.15)
   expect_true(grepl("blocked", result))
-  expect_true(grepl("gradient_15", result))
-  expect_true(grepl("gradient_25", result))
+  expect_true(grepl("gradient_1500", result))
+  expect_true(grepl("gradient_2500", result))
   expect_false(grepl("potential", result))
   expect_false(grepl("bridge", result))
 })
 
+test_that("legacy gradient_N format still parses correctly", {
+  # Backward compat: user-supplied labels via frs_break_find(label="gradient_15")
+  mock_labels <- data.frame(
+    label = c("blocked", "gradient_15", "gradient_25"),
+    stringsAsFactors = FALSE)
+
+  mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery",
+    function(conn, sql) mock_labels)
+
+  # gradient_15 (legacy) parsed as 0.15, blocks species at 0.15 access
+  result <- .frs_access_label_filter("mock", "breaks", 0.15)
+  expect_true(grepl("gradient_15", result))
+  expect_true(grepl("gradient_25", result))
+
+  # gradient_15 (legacy) parsed as 0.15, does NOT block species at 0.25
+  result_bt <- .frs_access_label_filter("mock", "breaks", 0.25)
+  expect_false(grepl("gradient_15", result_bt))
+  expect_true(grepl("gradient_25", result_bt))
+})
+
+test_that("mixed legacy and new format both parse correctly", {
+  # Mixed table — user-supplied legacy + auto-derived new format
+  mock_labels <- data.frame(
+    label = c("gradient_15", "gradient_1500", "gradient_0549"),
+    stringsAsFactors = FALSE)
+
+  mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery",
+    function(conn, sql) mock_labels)
+
+  # All three should be evaluated:
+  # - gradient_15 → 0.15 (legacy)
+  # - gradient_1500 → 0.15 (new)
+  # - gradient_0549 → 0.0549 (new)
+  # CO at 0.15 access: 0.15 >= 0.15 (blocks gradient_15 + gradient_1500),
+  # 0.0549 < 0.15 (gradient_0549 does not block)
+  result <- .frs_access_label_filter("mock", "breaks", 0.15)
+  expect_true(grepl("gradient_15'", result))    # legacy 15
+  expect_true(grepl("gradient_1500", result))    # new 15
+  expect_false(grepl("gradient_0549", result))   # 5.49% < 15%
+})
+
 test_that("custom label_block block", {
   mock_labels <- data.frame(
-    label = c("blocked", "potential", "passable", "gradient_15"),
+    label = c("blocked", "potential", "passable", "gradient_1500"),
     stringsAsFactors = FALSE)
 
   mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery",
@@ -56,20 +97,20 @@ test_that("custom label_block block", {
     label_block = c("blocked", "potential"))
   expect_true(grepl("blocked", result))
   expect_true(grepl("potential", result))
-  expect_true(grepl("gradient_15", result))
+  expect_true(grepl("gradient_1500", result))
   expect_false(grepl("passable", result))
 })
 
 test_that("gradient labels below threshold do not block", {
   mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery", function(conn, sql) {
-    data.frame(label = c("gradient_15", "gradient_25"),
+    data.frame(label = c("gradient_1500", "gradient_2500"),
                stringsAsFactors = FALSE)
   })
 
-  # At 25% threshold: only gradient_25 blocks, gradient_15 does not
+  # At 25% threshold: only gradient_2500 blocks, gradient_1500 does not
   result <- .frs_access_label_filter("mock", "breaks", 0.25)
-  expect_true(grepl("gradient_25", result))
-  expect_false(grepl("gradient_15", result))
+  expect_true(grepl("gradient_2500", result))
+  expect_false(grepl("gradient_1500", result))
 })
 
 test_that("no blocking labels returns FALSE", {
@@ -80,4 +121,48 @@ test_that("no blocking labels returns FALSE", {
 
   result <- .frs_access_label_filter("mock", "breaks", 0.15)
   expect_equal(result, "FALSE")
+})
+
+test_that("malformed gradient labels do not block", {
+  # Edge cases that should NOT match either format
+  mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery", function(conn, sql) {
+    data.frame(label = c("gradient_15000",   # 5 digits — not legacy or new
+                         "gradient_5p49",    # decimal separator — not supported
+                         "gradient_-100",    # negative — not supported
+                         "gradient_",         # empty number
+                         "gradient",          # no underscore
+                         "Gradient_1500"),    # capital G
+               stringsAsFactors = FALSE)
+  })
+
+  result <- .frs_access_label_filter("mock", "breaks", 0.15)
+  expect_equal(result, "FALSE")
+})
+
+test_that("gradient_NNNN with various values parses to expected fractions", {
+  # Direct test of the new format parser
+  test_cases <- list(
+    list(label = "gradient_0249", expected_block_at = 0.0249),
+    list(label = "gradient_0500", expected_block_at = 0.05),
+    list(label = "gradient_0549", expected_block_at = 0.0549),
+    list(label = "gradient_1000", expected_block_at = 0.10),
+    list(label = "gradient_1500", expected_block_at = 0.15),
+    list(label = "gradient_2500", expected_block_at = 0.25)
+  )
+  for (tc in test_cases) {
+    mockery::stub(.frs_access_label_filter, "DBI::dbGetQuery", function(conn, sql) {
+      data.frame(label = tc$label, stringsAsFactors = FALSE)
+    })
+    # Species with access threshold equal to the label's value: blocks
+    result <- .frs_access_label_filter("mock", "breaks", tc$expected_block_at)
+    expect_true(grepl(tc$label, result),
+      info = sprintf("%s should block species at access %s",
+                     tc$label, tc$expected_block_at))
+    # Species with access threshold higher than label: does NOT block
+    result_above <- .frs_access_label_filter("mock", "breaks",
+                                              tc$expected_block_at + 0.01)
+    expect_equal(result_above, "FALSE",
+      info = sprintf("%s should not block species at access > %s",
+                     tc$label, tc$expected_block_at))
+  }
 })


### PR DESCRIPTION
## Summary

Fixes the precision-loss bug introduced in v0.11.0 (#101) where distinct gradient thresholds collapsed to the same `gradient_N` label.

### Root cause

In `R/frs_habitat.R`, two related uses of `as.integer(thr * 100)`:
- Dedup: `!duplicated(as.integer(all_thresholds * 100))` collapsed `0.05` and `0.0549` (both → 5), silently dropping one
- Label: `sprintf("gradient_%d", as.integer(thr * 100))` produced `gradient_5` for both, masking the difference

A user inspecting the breaks table would see `gradient_5` and assume 5%, when the actual break could be at 5.49%.

### Fix

- New label format `gradient_NNNN` — 4-digit zero-padded basis points (threshold × 10000)
  - `0.05` → `gradient_0500`
  - `0.0549` → `gradient_0549` (was `gradient_5`, colliding with 0.05)
  - `0.1049` → `gradient_1049`
  - `0.15` → `gradient_1500`
- Resolution: 1 basis point (0.0001) — sufficient for any biologically meaningful threshold
- Centralized in `.frs_gradient_label()` helper
- Replace lossy `as.integer(...)` dedup with `unique()` on actual numeric values
- New `.frs_validate_gradient_thresholds()` helper that errors on:
  - Out-of-range values (must be in [0, 1])
  - Excess precision beyond basis points (e.g. `0.05001`)
  - Label collisions
  - NA values
- Validation runs at function entry AND on the combined access + extras set, catching collisions even when user-supplied custom `params` produce out-of-precision values via the auto-derive path
- Parser `.frs_access_label_filter()` accepts BOTH the new `gradient_NNNN` format and the legacy `gradient_N` format for backward compat with user-supplied labels (e.g. `frs_break_find(label = "gradient_15")`)

### Hardening

The user asked: "are there extra tests we can add that ensure it will not get mangled with complex inputs? are there errors for differing inputs that would result in equal table output names?"

Yes — the validation helper now catches:
- 0.05001 → "exceed basis-point precision" error
- 1.5 → "must be in [0, 1]" error
- -0.01 → "must be in [0, 1]" error
- NA → "contains NA" error
- Distinct values producing same label → "duplicate labels" error

## Test plan

- [x] 6 input validation tests (range, precision, NA, collision)
- [x] 9 label parser tests (new format, legacy format, mixed, malformed labels, parametric value-to-fraction sweep)
- [x] 1 regression test for #110 (`breaks_gradient = c(0.05, 0.0549)` produces distinct breaks)
- [x] Full suite: 600 tests pass (572 prior + 28 new)
- [x] Code-check 2 rounds:
  - Round 1: found latent bug — auto-derived path bypassed validation. Fixed.
  - Round 2: clean
- [x] Workflow hygiene: archived stale planning files from PR #56, used proper PWF at `planning/active/` for this issue

Fixes #110
Relates to #101
Relates to NewGraphEnvironment/sred-2025-2026#16
