### PR TITLE
Add per-rule gradient/channel_width threshold overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -876,6 +876,101 @@ Scripts and logs live together: `scripts/<module>/logs/`
 | Restoration planning | **Aquatic Restoration Planning (#5)** |
 | QGIS, Mergin, field forms | **Collaborative GIS (#3)** |
 
+# Planning Conventions
+
+How Claude manages structured planning for complex tasks using planning-with-files (PWF).
+
+## When to Plan
+
+Use PWF when a task has multiple phases, requires research, or involves more than ~5 tool calls. Triggers:
+- User says "let's plan this", "plan mode", "use planning", or invokes `/planning-init`
+- Complex issue work begins (multi-step, uncertain approach)
+- Claude judges the task warrants structured tracking
+
+Skip planning for single-file edits, quick fixes, or tasks with obvious next steps.
+
+## The Workflow
+
+1. **Explore first** — Enter plan mode (read-only). Read code, trace paths, understand the problem before proposing anything.
+2. **Plan to files** — Write the plan into 3 files in `planning/active/`:
+   - `task_plan.md` — Phases with checkbox tasks
+   - `findings.md` — Research, discoveries, technical analysis
+   - `progress.md` — Session log with timestamps and commit refs
+3. **Commit the plan** — Commit the planning files before starting implementation. This is the baseline.
+4. **Work in atomic commits** — Each commit bundles code changes WITH checkbox updates in the planning files. The diff shows both what was done and the checkbox marking it done.
+5. **Archive when complete** — Move `planning/active/` to `planning/archive/` via `/planning-archive`.
+
+## Atomic Commits (Critical)
+
+Every commit that completes a planned task MUST include:
+- The code/script changes
+- The checkbox update in `task_plan.md` (`- [ ]` -> `- [x]`)
+- A progress entry in `progress.md` if meaningful
+
+This creates a git audit trail where `git log -- planning/` tells the full story. Each commit is self-documenting — you can backtrack with git and understand everything that happened.
+
+## File Formats
+
+### task_plan.md
+
+Phases with checkboxes. This is the core tracking file.
+
+```markdown
+# Task Plan
+
+## Phase 1: [Name]
+- [ ] Task description
+- [ ] Another task
+
+## Phase 2: [Name]
+- [ ] Task description
+```
+
+Mark tasks done as they're completed: `- [x] Task description`
+
+### findings.md
+
+Append-only research log. Discoveries, technical analysis, things learned.
+
+```markdown
+# Findings
+
+## [Topic]
+[What was found, with source/date]
+```
+
+### progress.md
+
+Session entries with commit references.
+
+```markdown
+# Progress
+
+## Session YYYY-MM-DD
+- Completed: [items]
+- Commits: [refs]
+- Next: [items]
+```
+
+## Directory Structure
+
+```
+planning/
+  active/          <- Current work (3 PWF files)
+  archive/         <- Completed issues
+    YYYY-MM-issue-N-slug/
+```
+
+If `planning/` doesn't exist in the repo, run `/planning-init` first.
+
+## Skills
+
+| Skill | When to use |
+|-------|-------------|
+| `/planning-init` | First time in a repo — creates directory structure |
+| `/planning-update` | Mid-session — sync checkboxes and progress |
+| `/planning-archive` | Issue complete — archive and create fresh active/ |
+
 # R Package Development Conventions
 
 Standards for R package development across New Graph Environment repositories.

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -132,7 +132,8 @@ frs_params <- function(conn = NULL,
   }
 
   valid_predicates <- c("edge_types", "edge_types_explicit",
-                        "waterbody_type", "lake_ha_min", "thresholds")
+                        "waterbody_type", "lake_ha_min", "thresholds",
+                        "gradient", "channel_width")
 
   for (sp in names(raw)) {
     sp_block <- raw[[sp]]
@@ -245,6 +246,17 @@ frs_params <- function(conn = NULL,
       stop(sprintf(
         "rules YAML %s/%s rule %d edge_types must be a list of category names",
         sp, habitat, idx), call. = FALSE)
+    }
+  }
+
+  for (field in c("gradient", "channel_width")) {
+    val <- rule[[field]]
+    if (!is.null(val)) {
+      if (!is.numeric(val) || length(val) != 2) {
+        stop(sprintf(
+          "rules YAML %s/%s rule %d %s must be a numeric vector of length 2 [min, max]",
+          sp, habitat, idx, field), call. = FALSE)
+      }
     }
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -216,19 +216,34 @@
     }
   }
 
-  if (inherit_thresholds && !is.null(csv_thresholds)) {
-    if (!is.null(csv_thresholds$gradient)) {
-      g <- csv_thresholds$gradient
-      parts <- c(parts, sprintf(
-        "s.gradient BETWEEN %s AND %s",
-        .frs_sql_num(g[1]), .frs_sql_num(g[2])))
-    }
-    if (!is.null(csv_thresholds$channel_width)) {
-      cw <- csv_thresholds$channel_width
-      parts <- c(parts, sprintf(
-        "s.channel_width BETWEEN %s AND %s",
-        .frs_sql_num(cw[1]), .frs_sql_num(cw[2])))
-    }
+  # Gradient: rule-level override wins, then CSV inheritance fills gap.
+  # A rule with gradient: [0, 9999] explicitly overrides the CSV value.
+  # A rule without gradient inherits from CSV when thresholds: true.
+  if (!is.null(rule[["gradient"]])) {
+    g <- rule[["gradient"]]
+    parts <- c(parts, sprintf(
+      "s.gradient BETWEEN %s AND %s",
+      .frs_sql_num(g[1]), .frs_sql_num(g[2])))
+  } else if (inherit_thresholds && !is.null(csv_thresholds) &&
+             !is.null(csv_thresholds$gradient)) {
+    g <- csv_thresholds$gradient
+    parts <- c(parts, sprintf(
+      "s.gradient BETWEEN %s AND %s",
+      .frs_sql_num(g[1]), .frs_sql_num(g[2])))
+  }
+
+  # Channel width: same override-then-inherit pattern.
+  if (!is.null(rule[["channel_width"]])) {
+    cw <- rule[["channel_width"]]
+    parts <- c(parts, sprintf(
+      "s.channel_width BETWEEN %s AND %s",
+      .frs_sql_num(cw[1]), .frs_sql_num(cw[2])))
+  } else if (inherit_thresholds && !is.null(csv_thresholds) &&
+             !is.null(csv_thresholds$channel_width)) {
+    cw <- csv_thresholds$channel_width
+    parts <- c(parts, sprintf(
+      "s.channel_width BETWEEN %s AND %s",
+      .frs_sql_num(cw[1]), .frs_sql_num(cw[2])))
   }
 
   if (length(parts) == 0) return("(TRUE)")

--- a/inst/extdata/parameters_habitat_rules.yaml
+++ b/inst/extdata/parameters_habitat_rules.yaml
@@ -14,7 +14,9 @@
 #   edge_types_explicit: list of integer FWA edge_type codes
 #   waterbody_type: 'L' (lake), 'R' (river polygon), 'W' (wetland)
 #   lake_ha_min: minimum lake area for waterbody_type=L rules
-#   thresholds: false  — skip CSV threshold inheritance for this rule
+#   gradient: [min, max]  — override CSV gradient (rule value wins)
+#   channel_width: [min, max]  — override CSV channel_width (rule value wins)
+#   thresholds: false  — skip ALL CSV threshold inheritance for this rule
 
 BT:
   spawn:
@@ -22,11 +24,13 @@ BT:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -38,11 +42,13 @@ CH:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -54,6 +60,7 @@ CM:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear: []
 CO:
   spawn:
@@ -61,11 +68,13 @@ CO:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -77,6 +86,7 @@ PK:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear: []
 SK:
   spawn:
@@ -84,6 +94,7 @@ SK:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - waterbody_type: L
   rear:
   - waterbody_type: L
@@ -94,11 +105,13 @@ ST:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -110,11 +123,13 @@ WCT:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -126,6 +141,7 @@ KO:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - waterbody_type: L
   rear:
   - waterbody_type: L
@@ -136,11 +152,13 @@ RB:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - edge_types_explicit:
     - 1050
     - 1150
@@ -152,9 +170,11 @@ GR:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   rear:
   - edge_types:
     - stream
     - canal
   - waterbody_type: R
+    channel_width: [0, 9999]
   - waterbody_type: L

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,5 @@
+# Findings: Issue #116
+
+Small change. `.frs_rule_to_sql()` currently has all-or-nothing CSV threshold inheritance. Need per-field override: if a rule specifies `gradient` or `channel_width`, use the rule value; else inherit from CSV when `thresholds: true`.
+
+The `gradient` and `channel_width` keys need to be added to `valid_predicates` in `.frs_validate_rule()`. Validate as numeric vectors of length 2 (min, max).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,10 @@
+# Progress: Issue #116 — Per-rule threshold overrides
+
+### 2026-04-09
+- Branch `116-per-rule-threshold-overrides` created
+- PWF initialized
+- `.frs_rule_to_sql()`: rule-level gradient/channel_width checked BEFORE CSV inheritance. If rule has the field, use it; else inherit from CSV when thresholds: true
+- `.frs_validate_rule()`: accept gradient and channel_width keys, validate as numeric vector of length 2 [min, max]
+- Bundled YAML: all `waterbody_type: R` rules now have `channel_width: [0, 9999]` (skip cw_min on river polygons, matching bcfishpass pattern)
+- 5 new tests: gradient override, cw override, override + thresholds=false, bad format
+- 657 tests pass

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,18 @@
+# Task: Per-rule threshold overrides in YAML (issue #116)
+
+## Goal
+
+Allow rules to specify `gradient` and `channel_width` overrides that win over CSV inheritance. Currently it's all-or-nothing (`thresholds: true/false`). This enables the bcfishpass pattern where `waterbody_type=R` skips channel_width_min but keeps gradient.
+
+## Status: in progress
+
+## Phases
+
+- [x] Branch + PWF init
+- [x] Update `.frs_rule_to_sql()` — rule-level gradient/channel_width overrides CSV inheritance
+- [x] Update `.frs_validate_rule()` — accept gradient and channel_width keys, validate as numeric [min, max]
+- [x] 5 new tests: gradient override, channel_width override, override with thresholds=false, bad format validation
+- [x] Update bundled YAML: all R-polygon rules get `channel_width: [0, 9999]`
+- [x] 657 tests pass
+- [ ] Code-check
+- [ ] PR + merge + NEWS + archive PWF

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -299,6 +299,63 @@ test_that(".frs_rules_to_sql CO rear pattern: 4 rules with carve-out", {
   expect_equal(length(gregexpr("gradient BETWEEN", sql)[[1]]), 3)
 })
 
+test_that(".frs_rule_to_sql rule-level gradient overrides CSV", {
+  rule <- list(
+    waterbody_type = "R",
+    gradient = c(0, 0.10))  # rule-level override
+  csv_thresholds <- list(
+    gradient = c(0, 0.0549),
+    channel_width = c(2, 9999))
+  sql <- .frs_rule_to_sql(rule, csv_thresholds)
+  # Rule gradient (0.10) should win over CSV gradient (0.0549)
+  expect_match(sql, "gradient BETWEEN 0 AND 0\\.1")
+  expect_false(grepl("0\\.0549", sql))
+  # Channel width still inherited from CSV
+  expect_match(sql, "channel_width BETWEEN 2 AND 9999")
+})
+
+test_that(".frs_rule_to_sql rule-level channel_width overrides CSV", {
+  rule <- list(
+    waterbody_type = "R",
+    channel_width = c(0, 9999))  # override: skip cw_min
+  csv_thresholds <- list(
+    gradient = c(0, 0.0549),
+    channel_width = c(2, 9999))
+  sql <- .frs_rule_to_sql(rule, csv_thresholds)
+  # Rule channel_width [0, 9999] should win (min=0 not 2)
+  expect_match(sql, "channel_width BETWEEN 0 AND 9999")
+  # Gradient still inherited from CSV
+  expect_match(sql, "gradient BETWEEN 0 AND 0\\.0549")
+})
+
+test_that(".frs_rule_to_sql rule-level override WITH thresholds=false", {
+  # If both gradient override and thresholds=false, override still applies
+  # (rule-level values always apply; thresholds=false only affects inheritance)
+  rule <- list(
+    waterbody_type = "R",
+    gradient = c(0, 0.10),
+    thresholds = FALSE)
+  csv_thresholds <- list(
+    gradient = c(0, 0.0549),
+    channel_width = c(2, 9999))
+  sql <- .frs_rule_to_sql(rule, csv_thresholds)
+  # Rule gradient (0.10) should be present (explicit, not inherited)
+  expect_match(sql, "gradient BETWEEN 0 AND 0\\.1")
+  # Channel width should NOT be present (thresholds: false skips inheritance,
+  # and there's no rule-level cw override)
+  expect_false(grepl("channel_width", sql))
+})
+
+test_that(".frs_validate_rule errors on bad gradient format", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  spawn:",
+    "    - gradient: 0.05"), tmp)
+  expect_error(.frs_load_rules(tmp), "numeric vector of length 2")
+})
+
 
 # Integration tests — require DB connection
 


### PR DESCRIPTION
## Summary

- Per-rule `gradient` and `channel_width` overrides in the habitat rules YAML. Rule-level values win over CSV inheritance; missing fields inherit from CSV when `thresholds: true`.
- Enables the bcfishpass pattern where `waterbody_type=R` rules skip `channel_width_min` (river polygons have unreliable widths) while still applying gradient thresholds
- Bundled YAML updated: all `waterbody_type: R` rules now have `channel_width: [0, 9999]`
- Validation added: `gradient` and `channel_width` must be numeric vectors of length 2 `[min, max]`

## Test plan

- [x] 5 new tests: gradient override wins over CSV, channel_width override wins, override + thresholds=false interaction, bad format validation
- [x] Full suite: 657 tests pass
- [x] Code-check: clean (1 round)

Fixes #116
Relates to NewGraphEnvironment/sred-2025-2026#16
