### PR TITLE
Separate min_length from distance in frs_break_find

### DIFF
--- a/R/frs_break.R
+++ b/R/frs_break.R
@@ -18,7 +18,11 @@
 #'   gradient exceeds this produce a break point at the entry.
 #' @param interval Integer. Not used (kept for compatibility). Default `100`.
 #' @param distance Integer. Upstream window in metres for gradient
-#'   computation AND minimum island length. Default `100`.
+#'   computation at each vertex. Default `100`.
+#' @param min_length Integer. Minimum island length in metres to keep.
+#'   Default `0` (keep all islands — a 30m waterfall at 20% gradient is
+#'   a real barrier). Set to `100` to restore pre-0.12.2 behavior where
+#'   short steep sections were filtered out.
 #' @param overwrite Logical. If `TRUE`, drop `to` before creating.
 #'   Default `TRUE`.
 #'
@@ -62,6 +66,7 @@
 frs_break_find <- function(conn, table, to = "working.breaks",
                            attribute = NULL, threshold = NULL,
                            interval = 100L, distance = 100L,
+                           min_length = 0L,
                            overwrite = TRUE) {
   .frs_validate_identifier(table, "source table")
   .frs_validate_identifier(to, "destination table")
@@ -75,7 +80,7 @@ frs_break_find <- function(conn, table, to = "working.breaks",
   }
 
   .frs_break_find_attribute(conn, table, to, attribute, threshold,
-                             interval, distance)
+                             interval, distance, min_length)
 
   invisible(conn)
 }
@@ -102,15 +107,18 @@ frs_break_find <- function(conn, table, to = "working.breaks",
 #' @param threshold Numeric. Gradient threshold.
 #' @param interval Not used (kept for API compatibility).
 #' @param distance Integer. Upstream window in metres for gradient
-#'   computation AND minimum island length. Default 100.
+#'   computation. Default 100.
+#' @param min_length Integer. Minimum island length to keep. Default 0.
 #' @noRd
 .frs_break_find_attribute <- function(conn, table, to, attribute, threshold,
-                                      interval, distance) {
+                                      interval, distance, min_length) {
   .frs_validate_identifier(attribute, "attribute column")
   stopifnot(is.numeric(threshold), length(threshold) == 1)
   stopifnot(is.numeric(distance), length(distance) == 1)
+  stopifnot(is.numeric(min_length), length(min_length) == 1)
 
   dist <- as.integer(distance)
+  min_len <- as.integer(min_length)
 
   sql <- sprintf(
     "CREATE TABLE %s AS
@@ -189,7 +197,7 @@ frs_break_find <- function(conn, table, to = "working.breaks",
     to, table,
     dist, dist, dist, dist, dist,
     .frs_sql_num(threshold),
-    dist
+    min_len
   )
   .frs_db_execute(conn, sql)
 }

--- a/man/frs_break_find.Rd
+++ b/man/frs_break_find.Rd
@@ -12,6 +12,7 @@ frs_break_find(
   threshold = NULL,
   interval = 100L,
   distance = 100L,
+  min_length = 0L,
   overwrite = TRUE
 )
 }
@@ -33,7 +34,12 @@ gradient exceeds this produce a break point at the entry.}
 \item{interval}{Integer. Not used (kept for compatibility). Default \code{100}.}
 
 \item{distance}{Integer. Upstream window in metres for gradient
-computation AND minimum island length. Default \code{100}.}
+computation at each vertex. Default \code{100}.}
+
+\item{min_length}{Integer. Minimum island length in metres to keep.
+Default \code{0} (keep all islands — a 30m waterfall at 20\% gradient is
+a real barrier). Set to \code{100} to restore pre-0.12.2 behavior where
+short steep sections were filtered out.}
 
 \item{overwrite}{Logical. If \code{TRUE}, drop \code{to} before creating.
 Default \code{TRUE}.}
@@ -90,6 +96,7 @@ Other habitat:
 \code{\link{frs_break_validate}()},
 \code{\link{frs_categorize}()},
 \code{\link{frs_classify}()},
+\code{\link{frs_cluster}()},
 \code{\link{frs_col_generate}()},
 \code{\link{frs_col_join}()},
 \code{\link{frs_extract}()},

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,3 @@
+# Findings: Issue #118
+
+`distance` param does double duty: gradient sampling window AND minimum island length. Fix: separate into `distance` (window, unchanged) + `min_length` (island filter, default 0).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,10 @@
+# Progress: Issue #118 — min_length filter
+
+### 2026-04-09
+- Branch `118-min-length-filter` created
+- PWF initialized
+- Added `min_length` param (default 0) to `frs_break_find()` and `.frs_break_find_attribute()`
+- SQL: `WHERE island_length >= min_len` (was `dist`)
+- Updated roxygen docs
+- 657 tests pass
+- ADMS verification: 137 barriers at 15% (min_length=0) vs 98 (min_length=100) — 39 short barriers recovered

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,15 @@
+# Task: frs_break_find minimum island length filter (issue #118)
+
+## Goal
+Separate `distance` (gradient sampling window) from `min_length` (minimum island length). Default `min_length = 0` keeps ALL islands — a 30m waterfall at 20% gradient is a real barrier. The 100m default was silently dropping real barriers.
+
+## Status: in progress
+
+## Phases
+- [x] Branch + PWF init
+- [x] Add `min_length` param to `frs_break_find()` + `.frs_break_find_attribute()`
+- [x] Update SQL: `island_length >= %d` uses `min_len` not `dist`
+- [x] Update roxygen docs
+- [x] 657 tests pass, ADMS verification: 137 barriers (was 98, +39 recovered)
+- [ ] Code-check
+- [ ] PR + merge + NEWS + archive


### PR DESCRIPTION
## Summary

- Separate `min_length` parameter (default 0) from `distance` in `frs_break_find()`. Previously `distance` (100m) did double duty as gradient sampling window AND minimum island length filter, silently dropping short steep sections like waterfalls and bedrock cascades.
- Default `min_length = 0` keeps all islands (matching bcfishpass v0.5.0). Pass `min_length = 100` to restore pre-0.12.2 behavior.
- ADMS sub-basin at 15% threshold: 137 barriers (was 98) — 39 short barriers recovered

## Test plan

- [x] 657 existing tests pass (no regressions)
- [x] ADMS verification: 137 barriers (min_length=0) vs 98 (min_length=100)
- [x] Code-check: clean (sprintf arg count verified — 9 args matching 9 format specifiers)

Fixes #118
Relates to NewGraphEnvironment/sred-2025-2026#16
