### PR TITLE
Add gradient_recompute parameter for post-segmentation gradient assignment

### DIFF
--- a/R/frs_col_generate.R
+++ b/R/frs_col_generate.R
@@ -14,6 +14,9 @@
 #' @param table Character. Schema-qualified working table name
 #'   (from [frs_extract()]).
 #' @param geom_col Character. Name of the geometry column. Default `"geom"`.
+#' @param exclude Character vector or `NULL`. Column names to skip
+#'   (e.g. `"gradient"` to preserve parent-segment gradient after
+#'   splitting). Default `NULL` (regenerate all columns).
 #'
 #' @return `conn` invisibly, for pipe chaining.
 #'
@@ -75,7 +78,8 @@
 #' DBI::dbExecute(conn, "DROP TABLE IF EXISTS working.breaks")
 #' DBI::dbDisconnect(conn)
 #' }
-frs_col_generate <- function(conn, table, geom_col = "geom") {
+frs_col_generate <- function(conn, table, geom_col = "geom",
+                             exclude = NULL) {
   .frs_validate_identifier(table, "table")
   .frs_validate_identifier(geom_col, "geometry column")
 
@@ -107,6 +111,11 @@ frs_col_generate <- function(conn, table, geom_col = "geom") {
       geom_col
     )
   )
+
+  # Filter out excluded columns
+  if (!is.null(exclude)) {
+    generated_defs <- generated_defs[!names(generated_defs) %in% exclude]
+  }
 
   # For each column: drop if exists, then add as generated
   for (col_name in names(generated_defs)) {

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -48,6 +48,10 @@
 #'   Auto-derived breaks give cluster analysis ([frs_cluster()]) the
 #'   gradient resolution to detect within-segment steep sections that
 #'   would otherwise be hidden by averaging.
+#' @param gradient_recompute Logical. If `TRUE` (default), recompute
+#'   gradient from DEM vertices after splitting segments. If `FALSE`,
+#'   child segments inherit the parent gradient. See
+#'   [frs_network_segment()] for details.
 #' @param rules Character path to a habitat rules YAML, `FALSE`, or
 #'   `NULL`. Default `NULL` uses the bundled
 #'   `inst/extdata/parameters_habitat_rules.yaml`. Pass a path string
@@ -178,6 +182,7 @@ frs_habitat <- function(conn, wsg = NULL,
                         gate = TRUE,
                         label_block = "blocked",
                         rules = NULL,
+                        gradient_recompute = TRUE,
                         params = NULL,
                         params_fresh = NULL,
                         workers = 1L,
@@ -285,8 +290,8 @@ frs_habitat <- function(conn, wsg = NULL,
 
   # -- Per-job worker function -------------------------------------------------
   .run_job <- function(spec, conn_params, break_sources, breaks_gradient,
-                       params, params_fresh, to_streams, to_habitat,
-                       verbose) {
+                       gradient_recompute, params, params_fresh,
+                       to_streams, to_habitat, verbose) {
     # Connect (parallel) or reuse (sequential)
     if (!is.null(conn_params)) {
       library(fresh)
@@ -385,6 +390,7 @@ frs_habitat <- function(conn, wsg = NULL,
     frs_network_segment(w_conn, aoi = job_aoi,
       to = streams_tbl,
       break_sources = all_sources,
+      gradient_recompute = gradient_recompute,
       verbose = verbose && is.null(conn_params))
 
     n_seg <- DBI::dbGetQuery(w_conn,
@@ -524,7 +530,8 @@ frs_habitat <- function(conn, wsg = NULL,
       DBI::dbExecute(w_conn, sprintf("DROP TABLE IF EXISTS %s", tmp_tbl))
 
       frs_network_segment(w_conn, aoi = job_aoi,
-        to = streams_tbl, break_sources = all_sources, verbose = FALSE)
+        to = streams_tbl, break_sources = all_sources,
+        gradient_recompute = gradient_recompute, verbose = FALSE)
 
       n_seg <- DBI::dbGetQuery(w_conn,
         sprintf("SELECT count(*)::int AS n FROM %s", streams_tbl))$n
@@ -573,6 +580,7 @@ frs_habitat <- function(conn, wsg = NULL,
     },
       conn_params = conn_params, break_sources = break_sources,
       breaks_gradient = breaks_gradient,
+      gradient_recompute = gradient_recompute,
       params = params, params_fresh = params_fresh,
       to_streams = to_streams, to_habitat = to_habitat,
       gate = gate, label_block = label_block,
@@ -591,6 +599,7 @@ frs_habitat <- function(conn, wsg = NULL,
       res <- .run_job(spec, conn_params = NULL,
         break_sources = break_sources,
         breaks_gradient = breaks_gradient,
+        gradient_recompute = gradient_recompute,
         params = params, params_fresh = params_fresh,
         to_streams = to_streams, to_habitat = to_habitat,
         verbose = verbose)

--- a/R/frs_network_segment.R
+++ b/R/frs_network_segment.R
@@ -20,6 +20,11 @@
 #'   breaking). Each spec is a list with `table`, and optionally `where`,
 #'   `label`, `label_col`, `label_map`, `col_blk`, `col_measure`.
 #'   See [frs_break_find()] for details.
+#' @param gradient_recompute Logical. If `TRUE` (default), recompute
+#'   gradient from DEM vertices after splitting. If `FALSE`, child
+#'   segments inherit the parent segment gradient. Use `FALSE` to match
+#'   bcfishpass behavior where gradient is assigned from the original
+#'   FWA segment, not recomputed per sub-segment.
 #' @param overwrite Logical. If `TRUE`, drop `to` before creating.
 #'   Default `TRUE`.
 #' @param verbose Logical. Print progress. Default `TRUE`.
@@ -99,6 +104,7 @@
 frs_network_segment <- function(conn, aoi, to,
                                 source = "whse_basemapping.fwa_stream_networks_sp",
                                 break_sources = NULL,
+                                gradient_recompute = TRUE,
                                 overwrite = TRUE,
                                 verbose = TRUE) {
   .frs_validate_identifier(to, "output table")
@@ -185,8 +191,10 @@ frs_network_segment <- function(conn, aoi, to,
           round((proc.time() - t1)["elapsed"], 1), "s)\n", sep = "")
     }
 
-    # Recompute gradient/measures from new geometry
-    frs_col_generate(conn, to)
+    # Recompute measures/length from new geometry. Gradient optionally
+    # preserved from parent segment (gradient_recompute = FALSE).
+    frs_col_generate(conn, to,
+      exclude = if (isTRUE(gradient_recompute)) NULL else "gradient")
 
     # Keep breaks table for frs_habitat_classify (accessibility check)
     # Caller or frs_habitat can clean up later

--- a/man/frs_col_generate.Rd
+++ b/man/frs_col_generate.Rd
@@ -4,7 +4,7 @@
 \alias{frs_col_generate}
 \title{Convert Columns to PostgreSQL Generated Columns from Geometry}
 \usage{
-frs_col_generate(conn, table, geom_col = "geom")
+frs_col_generate(conn, table, geom_col = "geom", exclude = NULL)
 }
 \arguments{
 \item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object (from \code{\link[=frs_db_conn]{frs_db_conn()}}).}
@@ -13,6 +13,10 @@ frs_col_generate(conn, table, geom_col = "geom")
 (from \code{\link[=frs_extract]{frs_extract()}}).}
 
 \item{geom_col}{Character. Name of the geometry column. Default \code{"geom"}.}
+
+\item{exclude}{Character vector or \code{NULL}. Column names to skip
+(e.g. \code{"gradient"} to preserve parent-segment gradient after
+splitting). Default \code{NULL} (regenerate all columns).}
 }
 \value{
 \code{conn} invisibly, for pipe chaining.
@@ -92,6 +96,7 @@ Other habitat:
 \code{\link{frs_break_validate}()},
 \code{\link{frs_categorize}()},
 \code{\link{frs_classify}()},
+\code{\link{frs_cluster}()},
 \code{\link{frs_col_join}()},
 \code{\link{frs_extract}()},
 \code{\link{frs_feature_find}()},

--- a/man/frs_habitat.Rd
+++ b/man/frs_habitat.Rd
@@ -17,6 +17,7 @@ frs_habitat(
   gate = TRUE,
   label_block = "blocked",
   rules = NULL,
+  gradient_recompute = TRUE,
   params = NULL,
   params_fresh = NULL,
   workers = 1L,
@@ -83,6 +84,11 @@ Only consulted when \code{params = NULL}. If you pass your own
 object and \code{rules} here is ignored.
 
 See \code{\link[=frs_params]{frs_params()}} for the rules format.}
+
+\item{gradient_recompute}{Logical. If \code{TRUE} (default), recompute
+gradient from DEM vertices after splitting segments. If \code{FALSE},
+child segments inherit the parent gradient. See
+\code{\link[=frs_network_segment]{frs_network_segment()}} for details.}
 
 \item{params}{Named list from \code{\link[=frs_params]{frs_params()}}, or \code{NULL} to use
 bundled \code{parameters_habitat_thresholds.csv} and rules YAML.}

--- a/man/frs_network_segment.Rd
+++ b/man/frs_network_segment.Rd
@@ -10,6 +10,7 @@ frs_network_segment(
   to,
   source = "whse_basemapping.fwa_stream_networks_sp",
   break_sources = NULL,
+  gradient_recompute = TRUE,
   overwrite = TRUE,
   verbose = TRUE
 )
@@ -30,6 +31,12 @@ watershed group code, \code{sf} polygon, or \code{NULL}.}
 breaking). Each spec is a list with \code{table}, and optionally \code{where},
 \code{label}, \code{label_col}, \code{label_map}, \code{col_blk}, \code{col_measure}.
 See \code{\link[=frs_break_find]{frs_break_find()}} for details.}
+
+\item{gradient_recompute}{Logical. If \code{TRUE} (default), recompute
+gradient from DEM vertices after splitting. If \code{FALSE}, child
+segments inherit the parent segment gradient. Use \code{FALSE} to match
+bcfishpass behavior where gradient is assigned from the original
+FWA segment, not recomputed per sub-segment.}
 
 \item{overwrite}{Logical. If \code{TRUE}, drop \code{to} before creating.
 Default \code{TRUE}.}

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,7 @@
+# Findings: Issue #124
+
+`frs_col_generate()` replaces gradient with a GENERATED ALWAYS column from DEM Z vertices. After splitting a 4.9% parent at a break, children get recomputed gradients (3% + 7%). This is more accurate per sub-segment but diverges from bcfishpass which keeps the parent gradient.
+
+Fix: `frs_col_generate()` has a list of 4 generated columns (gradient, drm, urm, length). When `gradient_recompute = FALSE`, skip the gradient column but still regenerate the other 3 (measures and length MUST update after a split).
+
+Implementation: modify `frs_col_generate()` to accept an `exclude` parameter listing columns to skip. `frs_network_segment()` passes `exclude = "gradient"` when `gradient_recompute = FALSE`.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress: Issue #124
+
+### 2026-04-10
+- Branch `124-gradient-recompute` created
+- PWF initialized
+- `frs_col_generate(exclude=)` — skip named columns from regeneration
+- `frs_network_segment(gradient_recompute=)` — TRUE (default) recomputes, FALSE inherits parent
+- `frs_habitat(gradient_recompute=)` — passed through to both branches + mirai
+- 657 tests pass

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,13 @@
+# Task: gradient_recompute parameter (issue #124)
+
+## Goal
+Add `gradient_recompute` parameter to `frs_network_segment()`. Default TRUE (current behavior). FALSE = inherit parent gradient, only recompute measures + length.
+
+## Phases
+- [x] Branch + PWF
+- [x] `frs_col_generate()` gains `exclude` param — skip named columns
+- [x] `frs_network_segment()` gains `gradient_recompute` — passes `exclude = "gradient"` when FALSE
+- [x] `frs_habitat()` gains `gradient_recompute` — passes through to both sequential and mirai branches
+- [x] 657 tests pass
+- [ ] Code-check
+- [ ] PR + merge + NEWS + archive


### PR DESCRIPTION
## Summary

- `frs_col_generate(exclude =)` — skip named columns from regeneration (generic, reusable)
- `frs_network_segment(gradient_recompute =)` — `TRUE` (default) recomputes gradient from DEM vertices after splitting; `FALSE` inherits parent segment gradient
- `frs_habitat(gradient_recompute =)` — passes through to both sequential and mirai branches
- Addresses ~13% BT spawning divergence from bcfishpass v0.5.0 at full ADMS scale, where bcfishpass assigns gradient from the original FWA segment rather than recomputing per sub-segment

## Test plan

- [x] 657 tests pass (no regressions — default behavior unchanged)
- [x] Code-check: clean (1 round)

Fixes #124
Relates to NewGraphEnvironment/sred-2025-2026#16
