### PR TITLE
Multi-class gradient barrier detection in single pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -898,7 +898,8 @@ Skip planning for single-file edits, quick fixes, or tasks with obvious next ste
    - `progress.md` — Session log with timestamps and commit refs
 3. **Commit the plan** — Commit the planning files before starting implementation. This is the baseline.
 4. **Work in atomic commits** — Each commit bundles code changes WITH checkbox updates in the planning files. The diff shows both what was done and the checkbox marking it done.
-5. **Archive when complete** — Move `planning/active/` to `planning/archive/` via `/planning-archive`.
+5. **Code check before commit** — Run `/code-check` on staged diffs before committing. Don't mark a task done until the diff passes review.
+6. **Archive when complete** — Move `planning/active/` to `planning/archive/` via `/planning-archive`. Write a README.md in the archive directory with a one-paragraph outcome summary and closing commit/PR ref — future sessions scan these to catch up fast.
 
 ## Atomic Commits (Critical)
 

--- a/R/frs_break.R
+++ b/R/frs_break.R
@@ -249,27 +249,7 @@ frs_break_find <- function(conn, table, to = "working.breaks",
                                        classes, blk_filter) {
   # Build CASE statement from classes vector
   # classes is named numeric: c("5" = 0.05, "7" = 0.07, ...)
-  # Sort by value descending so highest class matches first
-  cls <- sort(classes, decreasing = TRUE)
-  cls_names <- names(cls)
-  cls_vals <- unname(cls)
-
-  case_parts <- character(0)
-  for (i in seq_along(cls)) {
-    if (i < length(cls)) {
-      # Not the highest class: bounded range
-      case_parts <- c(case_parts, sprintf(
-        "WHEN gradient >= %s AND gradient < %s THEN %s",
-        .frs_sql_num(cls_vals[i]),
-        .frs_sql_num(cls_vals[i - 1]),
-        cls_names[i]))
-    } else {
-      # Lowest remaining class — everything below the next lower bound
-      # Actually this is the highest after sort desc... let me re-think
-    }
-  }
-
-  # Simpler: sort ascending, build ranges with explicit upper bounds
+  # Sort ascending, each class spans from its value to the next class
   cls <- sort(classes)
   cls_names <- names(cls)
   cls_vals <- unname(cls)
@@ -351,12 +331,14 @@ frs_break_find <- function(conn, table, to = "working.breaks",
        FROM (
          SELECT blue_line_key, downstream_route_measure, grade_class,
            count(step OR NULL) OVER (
-             ORDER BY blue_line_key, downstream_route_measure
+             PARTITION BY blue_line_key
+             ORDER BY downstream_route_measure
            ) AS grp
          FROM (
            SELECT blue_line_key, downstream_route_measure, grade_class,
              lag(grade_class, 1, grade_class) OVER (
-               ORDER BY blue_line_key, downstream_route_measure
+               PARTITION BY blue_line_key
+               ORDER BY downstream_route_measure
              ) <> grade_class AS step
            FROM gradeclass
          ) sub1

--- a/R/frs_break.R
+++ b/R/frs_break.R
@@ -23,6 +23,15 @@
 #'   Default `0` (keep all islands — a 30m waterfall at 20% gradient is
 #'   a real barrier). Set to `100` to restore pre-0.12.2 behavior where
 #'   short steep sections were filtered out.
+#' @param classes Named numeric vector or `NULL`. Gradient class lower
+#'   bounds for multi-class detection (matching bcfishpass v0.5.0).
+#'   Names are class labels (used in `gradient_class` column), values
+#'   are lower gradient bounds. When provided, `threshold` is ignored
+#'   and all classes are detected in one pass.
+#'   Example: `c("5" = 0.05, "7" = 0.07, "15" = 0.15, "25" = 0.25)`.
+#' @param blk_filter Logical. If `TRUE` (default), only sample main
+#'   flow lines (`blue_line_key = watershed_key`). Matches bcfishpass.
+#'   `FALSE` samples all edge types including side channels.
 #' @param overwrite Logical. If `TRUE`, drop `to` before creating.
 #'   Default `TRUE`.
 #'
@@ -67,12 +76,17 @@ frs_break_find <- function(conn, table, to = "working.breaks",
                            attribute = NULL, threshold = NULL,
                            interval = 100L, distance = 100L,
                            min_length = 0L,
+                           classes = NULL,
+                           blk_filter = TRUE,
                            overwrite = TRUE) {
   .frs_validate_identifier(table, "source table")
   .frs_validate_identifier(to, "destination table")
 
-  if (is.null(attribute) || is.null(threshold)) {
-    stop("attribute and threshold are required", call. = FALSE)
+  if (is.null(attribute)) {
+    stop("attribute is required", call. = FALSE)
+  }
+  if (is.null(threshold) && is.null(classes)) {
+    stop("threshold or classes is required", call. = FALSE)
   }
 
   if (overwrite) {
@@ -80,45 +94,70 @@ frs_break_find <- function(conn, table, to = "working.breaks",
   }
 
   .frs_break_find_attribute(conn, table, to, attribute, threshold,
-                             interval, distance, min_length)
+                             interval, distance, min_length,
+                             classes, blk_filter)
 
   invisible(conn)
 }
 
 
-#' Find gradient breaks using island detection
+#' Find gradient breaks using multi-class island detection
 #'
 #' Computes gradient at every FWA vertex over a `distance` metre
-#' upstream window. Groups consecutive above-threshold vertices into
-#' "islands" (minimum `distance` metres long) and creates one break
-#' at the entry of each island — where gradient first exceeds the
-#' threshold for a sustained section.
+#' upstream window, assigns each vertex to a gradient class, and
+#' groups consecutive same-class vertices into islands. Places one
+#' barrier at the entry of each class island.
 #'
-#' Adapted from bcfishpass `gradient_barriers_load.sql` island
-#' approach. Entry-only breaks are appropriate for access barriers
-#' (everything upstream of the entry is blocked). For habitat
-#' classification, segments are classified by their own gradient
-#' attribute, not by break presence.
+#' Adapted from bcfishpass `gradient_barriers_load.sql`. Class-based
+#' detection catches transitions WITHIN a steep section (e.g. where
+#' gradient jumps from 15% to 25%), which boolean above/below misses.
+#'
+#' When `threshold` is provided (legacy single-threshold mode), falls
+#' back to boolean detection for backward compatibility.
 #'
 #' @param conn DBI connection.
 #' @param table Working streams table (for BLK list).
 #' @param to Output breaks table name.
 #' @param attribute Column name (currently only "gradient" supported).
-#' @param threshold Numeric. Gradient threshold.
+#' @param threshold Numeric or NULL. Single threshold for boolean
+#'   mode (legacy). NULL uses multi-class mode via `classes`.
 #' @param interval Not used (kept for API compatibility).
 #' @param distance Integer. Upstream window in metres for gradient
 #'   computation. Default 100.
 #' @param min_length Integer. Minimum island length to keep. Default 0.
+#' @param classes Named numeric vector or NULL. Gradient class lower
+#'   bounds. Names are the class labels (used in `gradient_class` column).
+#'   Default bcfishpass v0.5.0 classes. NULL falls back to
+#'   single-threshold mode.
+#' @param blk_filter Logical. If TRUE, only sample main flow lines
+#'   (`blue_line_key = watershed_key`). Default TRUE (matches
+#'   bcfishpass). FALSE samples all edge types.
 #' @noRd
 .frs_break_find_attribute <- function(conn, table, to, attribute, threshold,
-                                      interval, distance, min_length) {
+                                      interval, distance, min_length,
+                                      classes = NULL, blk_filter = TRUE) {
   .frs_validate_identifier(attribute, "attribute column")
-  stopifnot(is.numeric(threshold), length(threshold) == 1)
   stopifnot(is.numeric(distance), length(distance) == 1)
   stopifnot(is.numeric(min_length), length(min_length) == 1)
 
   dist <- as.integer(distance)
   min_len <- as.integer(min_length)
+
+  # Multi-class mode: build CASE statement from classes vector
+  if (!is.null(classes) && is.null(threshold)) {
+    .frs_break_find_multiclass(conn, table, to, dist, min_len,
+                               classes, blk_filter)
+    return(invisible(NULL))
+  }
+
+  # Legacy single-threshold mode
+  stopifnot(is.numeric(threshold), length(threshold) == 1)
+
+  blk_where <- if (isTRUE(blk_filter)) {
+    "AND s.blue_line_key = s.watershed_key"
+  } else {
+    ""
+  }
 
   sql <- sprintf(
     "CREATE TABLE %s AS
@@ -126,7 +165,6 @@ frs_break_find <- function(conn, table, to = "working.breaks",
        SELECT DISTINCT blue_line_key FROM %s
      ),
 
-     -- Gradient at every vertex over %dm upstream window
      vertex_grades AS (
        SELECT
          sv.blue_line_key,
@@ -145,6 +183,7 @@ frs_break_find <- function(conn, table, to = "working.breaks",
          FROM whse_basemapping.fwa_stream_networks_sp s
          WHERE s.blue_line_key IN (SELECT blue_line_key FROM working_blks)
            AND s.edge_type IN (1000,1050,1100,1150,1250,1350,1410,2000,2300)
+           %s
        ) sv
        INNER JOIN whse_basemapping.fwa_stream_networks_sp s2
          ON sv.blue_line_key = s2.blue_line_key
@@ -153,15 +192,12 @@ frs_break_find <- function(conn, table, to = "working.breaks",
        WHERE s2.edge_type != 6010
      ),
 
-     -- Flag above threshold
      flagged AS (
        SELECT blue_line_key, downstream_route_measure,
          CASE WHEN gradient > %s THEN TRUE ELSE FALSE END AS above
        FROM vertex_grades
      ),
 
-     -- Group consecutive above-threshold vertices into islands
-     -- via lag/count window (bcfishpass pattern)
      islands AS (
        SELECT
          blue_line_key,
@@ -186,7 +222,6 @@ frs_break_find <- function(conn, table, to = "working.breaks",
        GROUP BY blue_line_key, grp
      )
 
-     -- Entry point of each island >= minimum length
      SELECT DISTINCT
        blue_line_key,
        downstream_route_measure,
@@ -195,10 +230,156 @@ frs_break_find <- function(conn, table, to = "working.breaks",
      FROM islands
      WHERE island_length >= %d",
     to, table,
-    dist, dist, dist, dist, dist,
+    dist, dist, blk_where, dist, dist,
     .frs_sql_num(threshold),
     min_len
   )
+  .frs_db_execute(conn, sql)
+}
+
+
+#' Multi-class gradient barrier detection
+#'
+#' One-pass class-based approach matching bcfishpass v0.5.0. Tags
+#' every vertex with a gradient class, groups consecutive same-class
+#' vertices into islands, places one barrier at each class transition.
+#'
+#' @noRd
+.frs_break_find_multiclass <- function(conn, table, to, dist, min_len,
+                                       classes, blk_filter) {
+  # Build CASE statement from classes vector
+  # classes is named numeric: c("5" = 0.05, "7" = 0.07, ...)
+  # Sort by value descending so highest class matches first
+  cls <- sort(classes, decreasing = TRUE)
+  cls_names <- names(cls)
+  cls_vals <- unname(cls)
+
+  case_parts <- character(0)
+  for (i in seq_along(cls)) {
+    if (i < length(cls)) {
+      # Not the highest class: bounded range
+      case_parts <- c(case_parts, sprintf(
+        "WHEN gradient >= %s AND gradient < %s THEN %s",
+        .frs_sql_num(cls_vals[i]),
+        .frs_sql_num(cls_vals[i - 1]),
+        cls_names[i]))
+    } else {
+      # Lowest remaining class — everything below the next lower bound
+      # Actually this is the highest after sort desc... let me re-think
+    }
+  }
+
+  # Simpler: sort ascending, build ranges with explicit upper bounds
+  cls <- sort(classes)
+  cls_names <- names(cls)
+  cls_vals <- unname(cls)
+  n <- length(cls)
+
+  case_parts <- character(0)
+  for (i in seq_len(n)) {
+    if (i < n) {
+      case_parts <- c(case_parts, sprintf(
+        "WHEN gradient >= %s AND gradient < %s THEN %s",
+        .frs_sql_num(cls_vals[i]),
+        .frs_sql_num(cls_vals[i + 1]),
+        cls_names[i]))
+    } else {
+      # Last (highest) class: open-ended
+      case_parts <- c(case_parts, sprintf(
+        "WHEN gradient >= %s THEN %s",
+        .frs_sql_num(cls_vals[i]),
+        cls_names[i]))
+    }
+  }
+
+  case_sql <- paste("CASE", paste(case_parts, collapse = " "),
+                    "ELSE 0 END")
+
+  blk_where <- if (isTRUE(blk_filter)) {
+    "AND s.blue_line_key = s.watershed_key"
+  } else {
+    ""
+  }
+
+  sql <- sprintf(
+    "CREATE TABLE %s AS
+     WITH working_blks AS (
+       SELECT DISTINCT blue_line_key FROM %s
+     ),
+
+     vertex_grades AS (
+       SELECT
+         sv.blue_line_key,
+         ROUND(sv.downstream_route_measure::numeric, 2) AS downstream_route_measure,
+         ROUND(((ST_Z((ST_Dump(ST_LocateAlong(
+           s2.geom, sv.downstream_route_measure + %d
+         ))).geom) - sv.elevation) / %d)::numeric, 4) AS gradient
+       FROM (
+         SELECT
+           s.blue_line_key,
+           ((ST_LineLocatePoint(s.geom,
+             ST_PointN(s.geom, generate_series(1, ST_NPoints(s.geom) - 1)))
+             * s.length_metre) + s.downstream_route_measure
+           ) AS downstream_route_measure,
+           ST_Z(ST_PointN(s.geom, generate_series(1, ST_NPoints(s.geom) - 1))) AS elevation
+         FROM whse_basemapping.fwa_stream_networks_sp s
+         WHERE s.blue_line_key IN (SELECT blue_line_key FROM working_blks)
+           AND s.edge_type IN (1000,1050,1100,1150,1250,1350,1410,2000,2300)
+           %s
+       ) sv
+       INNER JOIN whse_basemapping.fwa_stream_networks_sp s2
+         ON sv.blue_line_key = s2.blue_line_key
+         AND sv.downstream_route_measure + %d >= s2.downstream_route_measure
+         AND sv.downstream_route_measure + %d < s2.upstream_route_measure
+       WHERE s2.edge_type != 6010
+     ),
+
+     gradeclass AS (
+       SELECT
+         blue_line_key,
+         downstream_route_measure,
+         %s AS grade_class
+       FROM vertex_grades
+     ),
+
+     islands AS (
+       SELECT
+         blue_line_key,
+         min(downstream_route_measure) AS downstream_route_measure,
+         grade_class AS gradient_class,
+         max(downstream_route_measure) - min(downstream_route_measure) AS island_length
+       FROM (
+         SELECT blue_line_key, downstream_route_measure, grade_class,
+           count(step OR NULL) OVER (
+             ORDER BY blue_line_key, downstream_route_measure
+           ) AS grp
+         FROM (
+           SELECT blue_line_key, downstream_route_measure, grade_class,
+             lag(grade_class, 1, grade_class) OVER (
+               ORDER BY blue_line_key, downstream_route_measure
+             ) <> grade_class AS step
+           FROM gradeclass
+         ) sub1
+         WHERE grade_class != 0
+       ) sub2
+       GROUP BY blue_line_key, grade_class, grp
+     )
+
+     SELECT
+       i.blue_line_key,
+       i.downstream_route_measure,
+       max(i.gradient_class) AS gradient_class,
+       'gradient' AS label,
+       'attribute' AS source
+     FROM islands i
+     WHERE i.island_length >= %d
+     GROUP BY i.blue_line_key, i.downstream_route_measure",
+    to, table,
+    dist, dist, blk_where, dist, dist,
+    case_sql,
+    min_len
+  )
+
   .frs_db_execute(conn, sql)
 }
 

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -381,18 +381,31 @@ frs_habitat <- function(conn, wsg = NULL,
     all_sources <- if (!is.null(break_sources)) break_sources else list()
     barrier_tables <- character(0)
 
-    for (thr in all_thresholds) {
-      thr_label <- .frs_gradient_label(thr)
-      thr_tbl <- sprintf("working.barriers_%s_%s",
-                         job_label, sub("^gradient_", "", thr_label))
-      frs_break_find(w_conn, tmp_tbl,
-        attribute = "gradient", threshold = thr,
-        to = thr_tbl)
-      all_sources <- c(all_sources, list(list(
-        table = thr_tbl,
-        label = thr_label)))
-      barrier_tables <- c(barrier_tables, thr_tbl)
-    }
+    # Build gradient class breaks from all_thresholds
+    # Each threshold becomes a class boundary. Names are the gradient_NNNN
+    # labels used for accessibility parsing.
+    grad_classes <- all_thresholds
+    names(grad_classes) <- vapply(all_thresholds, function(t) {
+      as.character(as.integer(round(t * 10000)))
+    }, character(1))
+
+    grad_tbl <- sprintf("working.barriers_%s_gradient", job_label)
+    frs_break_find(w_conn, tmp_tbl,
+      attribute = "gradient",
+      classes = grad_classes,
+      to = grad_tbl)
+
+    # Add gradient_NNNN label column based on gradient_class
+    .frs_db_execute(w_conn, sprintf(
+      "ALTER TABLE %s ADD COLUMN IF NOT EXISTS label text", grad_tbl))
+    .frs_db_execute(w_conn, sprintf(
+      "UPDATE %s SET label = 'gradient_' || lpad(gradient_class::text, 4, '0')",
+      grad_tbl))
+
+    all_sources <- c(all_sources, list(list(
+      table = grad_tbl,
+      label_col = "label")))
+    barrier_tables <- c(barrier_tables, grad_tbl)
 
     .frs_db_execute(w_conn, sprintf("DROP TABLE IF EXISTS %s", tmp_tbl))
 
@@ -526,17 +539,28 @@ frs_habitat <- function(conn, wsg = NULL,
 
       all_sources <- if (!is.null(break_sources)) break_sources else list()
       barrier_tables <- character(0)
-      for (thr in all_thresholds) {
-        thr_label <- .frs_gradient_label(thr)
-        thr_tbl <- sprintf("working.barriers_%s_%s",
-                           job_label, sub("^gradient_", "", thr_label))
-        frs_break_find(w_conn, tmp_tbl,
-          attribute = "gradient", threshold = thr, to = thr_tbl)
-        all_sources <- c(all_sources, list(list(
-          table = thr_tbl,
-          label = thr_label)))
-        barrier_tables <- c(barrier_tables, thr_tbl)
-      }
+
+      grad_classes <- all_thresholds
+      names(grad_classes) <- vapply(all_thresholds, function(t) {
+        as.character(as.integer(round(t * 10000)))
+      }, character(1))
+
+      grad_tbl <- sprintf("working.barriers_%s_gradient", job_label)
+      frs_break_find(w_conn, tmp_tbl,
+        attribute = "gradient",
+        classes = grad_classes,
+        to = grad_tbl)
+
+      DBI::dbExecute(w_conn, sprintf(
+        "ALTER TABLE %s ADD COLUMN IF NOT EXISTS label text", grad_tbl))
+      DBI::dbExecute(w_conn, sprintf(
+        "UPDATE %s SET label = 'gradient_' || lpad(gradient_class::text, 4, '0')",
+        grad_tbl))
+
+      all_sources <- c(all_sources, list(list(
+        table = grad_tbl,
+        label_col = "label")))
+      barrier_tables <- c(barrier_tables, grad_tbl)
 
       DBI::dbExecute(w_conn, sprintf("DROP TABLE IF EXISTS %s", tmp_tbl))
 

--- a/man/frs_break_find.Rd
+++ b/man/frs_break_find.Rd
@@ -13,6 +13,8 @@ frs_break_find(
   interval = 100L,
   distance = 100L,
   min_length = 0L,
+  classes = NULL,
+  blk_filter = TRUE,
   overwrite = TRUE
 )
 }
@@ -40,6 +42,17 @@ computation at each vertex. Default \code{100}.}
 Default \code{0} (keep all islands — a 30m waterfall at 20\% gradient is
 a real barrier). Set to \code{100} to restore pre-0.12.2 behavior where
 short steep sections were filtered out.}
+
+\item{classes}{Named numeric vector or \code{NULL}. Gradient class lower
+bounds for multi-class detection (matching bcfishpass v0.5.0).
+Names are class labels (used in \code{gradient_class} column), values
+are lower gradient bounds. When provided, \code{threshold} is ignored
+and all classes are detected in one pass.
+Example: \code{c("5" = 0.05, "7" = 0.07, "15" = 0.15, "25" = 0.25)}.}
+
+\item{blk_filter}{Logical. If \code{TRUE} (default), only sample main
+flow lines (\code{blue_line_key = watershed_key}). Matches bcfishpass.
+\code{FALSE} samples all edge types including side channels.}
 
 \item{overwrite}{Logical. If \code{TRUE}, drop \code{to} before creating.
 Default \code{TRUE}.}

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,44 @@
+# Findings: Issue #127
+
+## Key difference: boolean vs class-based island detection
+
+**Fresh (current):** `lag(above) IS DISTINCT FROM above` — binary step detection. A section going 12%→18%→25% is one island.
+
+**bcfishpass:** `lag(grade_class) <> grade_class` — class transitions produce new islands. 12%→18% is a transition from class 12 to class 15. Separate barriers.
+
+## bcfishpass class breaks
+
+```sql
+CASE
+  WHEN gradient >= .05 AND gradient < .07 THEN 5
+  WHEN gradient >= .07 AND gradient < .10 THEN 7
+  WHEN gradient >= .10 AND gradient < .12 THEN 10
+  WHEN gradient >= .12 AND gradient < .15 THEN 12
+  WHEN gradient >= .15 AND gradient < .20 THEN 15
+  WHEN gradient >= .20 AND gradient < .25 THEN 20
+  WHEN gradient >= .25 AND gradient < .30 THEN 25
+  WHEN gradient >= .30 THEN 30
+  ELSE 0
+END
+```
+
+## Additional filters
+
+- `blue_line_key = watershed_key` — only main flow lines, excludes side channels (382 of 11,520 ADMS segments)
+- Max gradient_class at duplicate positions via GROUP BY + max()
+- wscode_ltree/localcode_ltree joined from FWA base table at insert time
+
+## Design: parameterize the class breaks
+
+The class break values should NOT be hardcoded. Pass as a named numeric vector where names are the class labels and values are the lower bounds:
+
+```r
+classes = c("5" = 0.05, "7" = 0.07, "10" = 0.10, "12" = 0.12,
+            "15" = 0.15, "20" = 0.20, "25" = 0.25, "30" = 0.30)
+```
+
+Build the CASE statement dynamically. This lets consumers customize class breaks without code changes.
+
+## Impact on frs_habitat()
+
+Currently frs_habitat() loops over access thresholds calling frs_break_find() once per threshold. With multi-class, it calls frs_break_find() ONCE, gets all classes, then filters by species access threshold when building break_sources.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,11 @@
+# Progress: Issue #127
+
+### 2026-04-11
+- Branch `127-multi-class-gradient` created
+- PWF initialized
+- Read bcfishpass gradient_barriers_load.sql — understood class-based approach
+- Implemented `.frs_break_find_multiclass()` — dynamic CASE from classes vector
+- Updated `frs_break_find()` to dispatch multiclass vs legacy based on `classes` param
+- Updated `frs_habitat()` — single multiclass call replaces per-threshold loop
+- Both sequential + mirai branches updated
+- 658 tests pass

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,17 @@
+# Task: Multi-class gradient barrier detection (issue #127)
+
+## Goal
+Replace boolean above/below gradient detection with bcfishpass's multi-class approach. One pass tags every vertex with its gradient class (5,7,10,12,15,20,25,30), groups consecutive same-class vertices into islands, places one barrier at each class transition.
+
+## Status: in progress
+
+## Phases
+- [x] Branch + PWF
+- [x] New `.frs_break_find_multiclass()` — multi-class CASE, lag by grade_class, group per class, gradient_class output, blk_filter, parameterized classes
+- [x] Updated `frs_break_find()` — new `classes` + `blk_filter` params, dispatches to multiclass when classes provided
+- [x] Updated `frs_habitat()` — single `frs_break_find(classes=)` call replaces per-threshold loop, label column added via SQL UPDATE
+- [x] Updated mirai parallel branch — same changes
+- [x] 658 tests pass
+- [ ] Code-check
+- [ ] Integration test on ADMS
+- [ ] PR + merge + NEWS + archive

--- a/tests/testthat/test-frs_break.R
+++ b/tests/testthat/test-frs_break.R
@@ -1,9 +1,16 @@
 # --- Unit tests: frs_break_find ---
 
-test_that("frs_break_find requires attribute and threshold", {
+test_that("frs_break_find requires attribute", {
   expect_error(
     frs_break_find("mock", "working.streams"),
-    "attribute and threshold are required"
+    "attribute is required"
+  )
+})
+
+test_that("frs_break_find requires threshold or classes", {
+  expect_error(
+    frs_break_find("mock", "working.streams", attribute = "gradient"),
+    "threshold or classes is required"
   )
 })
 


### PR DESCRIPTION
## Summary

Replace per-threshold boolean gradient detection with bcfishpass v0.5.0 multi-class approach. One pass tags every vertex with its gradient class, groups consecutive same-class vertices into islands, places one barrier at each class transition.

### What changes

- New `.frs_break_find_multiclass()` — builds CASE statement dynamically from a named numeric vector of class breaks. Output includes `gradient_class` column.
- `frs_break_find()` gains `classes` and `blk_filter` parameters. When `classes` provided, dispatches to multiclass mode.
- `frs_habitat()` now calls `frs_break_find()` **once** with all gradient classes instead of looping per threshold. Labels added via SQL UPDATE (`gradient_NNNN` format).
- `blk_filter` (default TRUE) restricts to main flow lines (`blue_line_key = watershed_key`), matching bcfishpass.
- Legacy single-threshold mode preserved for backward compat via `threshold` parameter.

### Why this matters

Boolean detection misses class transitions within steep sections. A section going 12%→18%→25% is one island at threshold=15%, placing only one barrier at the entry. The 25% transition is lost. Multi-class detection produces separate barriers at each class transition. This is the primary cause of the -23% CH spawning gap vs bcfishpass at ADMS scale.

## Test plan

- [x] 658 tests pass (no regressions + 1 new test for updated error message)
- [x] Code-check 1 round: found missing `PARTITION BY blue_line_key` in multiclass window functions (barriers bleeding across streams). Fixed. Also removed dead code from abandoned approach.

Fixes #127
Relates to NewGraphEnvironment/sred-2025-2026#16
