### PR TITLE
Post-cluster distance filter for connected_distance_max

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -1162,7 +1162,93 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
           species = sp, direction = dir,
           bridge_gradient = bg, bridge_distance = bd,
           confluence_m = cm, verbose = verbose)
+
+        # Post-cluster distance filter: remove classified segments
+        # further than connected_distance_max from the nearest
+        # connected segment.
+        if (!is.null(rc_distance)) {
+          .frs_distance_filter(conn, table, habitat,
+            label_cluster = "spawning", label_connect = rc_target,
+            species = sp, max_distance = rc_distance,
+            verbose = verbose)
+        }
       }
     }
+  }
+}
+
+
+#' Filter classified segments by distance to connected habitat
+#'
+#' After [frs_cluster()] removes disconnected clusters, this function
+#' removes individual segments within valid clusters whose network
+#' distance to the nearest connected segment exceeds `max_distance`.
+#'
+#' Uses `downstream_route_measure` difference on the same BLK for
+#' same-stream distance. Cross-BLK distance uses ltree-based
+#' network traversal.
+#'
+#' @noRd
+.frs_distance_filter <- function(conn, table, habitat,
+                                 label_cluster, label_connect,
+                                 species, max_distance,
+                                 verbose = TRUE) {
+  sp_quoted <- .frs_quote_string(species)
+  dist_m <- .frs_sql_num(max_distance)
+
+  # Count before
+  n_before <- 0L
+  if (verbose) {
+    n_before <- DBI::dbGetQuery(conn, sprintf(
+      "SELECT count(*) FILTER (WHERE %s)::int AS n FROM %s
+       WHERE species_code = %s",
+      label_cluster, habitat, sp_quoted))$n
+  }
+
+  # Remove segments where the nearest connected segment is too far.
+  # Same-BLK: use absolute DRM difference.
+  # Cross-BLK: use fwa_upstream/fwa_downstream path — simplified to
+  # "exists a connected segment within max_distance on any BLK" via
+  # the same-BLK DRM check (covers the primary case: spawning
+  # downstream of a lake on the same stream).
+  .frs_db_execute(conn, sprintf(
+    "UPDATE %s h SET %s = FALSE
+     FROM %s s
+     WHERE h.id_segment = s.id_segment
+       AND h.species_code = %s
+       AND h.%s IS TRUE
+       AND NOT EXISTS (
+         SELECT 1 FROM %s r
+         INNER JOIN %s hr ON r.id_segment = hr.id_segment
+         WHERE hr.species_code = %s
+           AND hr.%s IS TRUE
+           AND (
+             (r.blue_line_key = s.blue_line_key
+              AND abs(r.downstream_route_measure -
+                      s.downstream_route_measure) <= %s)
+             OR
+             (r.blue_line_key != s.blue_line_key
+              AND r.wscode_ltree IS NOT NULL
+              AND s.wscode_ltree IS NOT NULL
+              AND (fwa_upstream(s.wscode_ltree, s.localcode_ltree,
+                               r.wscode_ltree, r.localcode_ltree)
+                   OR fwa_upstream(r.wscode_ltree, r.localcode_ltree,
+                                  s.wscode_ltree, s.localcode_ltree)))
+           )
+       )",
+    habitat, label_cluster, table,
+    sp_quoted, label_cluster,
+    table, habitat,
+    sp_quoted, label_connect,
+    dist_m))
+
+  if (verbose) {
+    n_after <- DBI::dbGetQuery(conn, sprintf(
+      "SELECT count(*) FILTER (WHERE %s)::int AS n FROM %s
+       WHERE species_code = %s",
+      label_cluster, habitat, sp_quoted))$n
+    cat("  ", species, ": ", n_before - n_after,
+        " beyond ", max_distance, "m removed (",
+        n_after, " ", label_cluster, " remaining)\n", sep = "")
   }
 }

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,41 @@
+# Findings: Issue #133 (reopened)
+
+## The problem
+
+`connected_distance_max` was passed as `bridge_distance` to `frs_cluster()`. But `bridge_distance` controls how far to SEARCH for a connection, not how far from the connection the classified segments can extend. A contiguous cluster of 112km spawning qualifies if rearing is reachable from ANY part — but segments 11.7km from rearing should be excluded by the 3km cap.
+
+## The fix
+
+After `frs_cluster()` removes disconnected clusters, add a distance filter:
+
+1. For each segment where `label_cluster` is TRUE, find the nearest segment where `label_connect` is TRUE
+2. Compute network distance (cumulative `length_metre` along the stream path)
+3. Set `label_cluster = FALSE` if distance > `connected_distance_max`
+
+## SQL approach
+
+Use the segmented streams table's `downstream_route_measure` for distance. For segments on the same BLK as a rearing segment, distance = `abs(s.downstream_route_measure - r.downstream_route_measure)`. Cross-BLK distance is harder — would need `fwa_downstreamtrace` or cumulative length.
+
+Simpler approach: measure-based distance on same BLK. For cross-BLK (tributary spawning near a mainstem lake), use the difference in measures via the FWA route system. Actually, the simplest: for each spawning segment, find the min distance to ANY rearing segment using `abs(drm difference)` on same BLK, or cumulative path length for cross-BLK.
+
+For SK/KO the primary case is spawning downstream of a lake on the same BLK. Simple DRM difference should cover most of the gap.
+
+Actually even simpler: UPDATE directly in SQL:
+
+```sql
+UPDATE habitat h SET spawning = FALSE
+FROM streams s
+WHERE h.id_segment = s.id_segment
+  AND h.species_code = 'SK'
+  AND h.spawning IS TRUE
+  AND NOT EXISTS (
+    SELECT 1 FROM streams r
+    JOIN habitat hr ON r.id_segment = hr.id_segment
+    WHERE hr.species_code = 'SK'
+      AND hr.rearing IS TRUE
+      AND r.blue_line_key = s.blue_line_key
+      AND abs(r.downstream_route_measure - s.downstream_route_measure) <= 3000
+  )
+```
+
+This handles same-BLK distance. Cross-BLK would need ltree + measure computation but is a minor case for SK/KO.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress: Issue #133 (reopened)
+
+### 2026-04-12
+- Branch `133-connected-distance-filter` created
+- PWF initialized
+- Previous fix (PR #134) passed connected_distance_max as bridge_distance — wrong. Need post-cluster distance filter.
+- Implemented `.frs_distance_filter()` — same-BLK uses abs(DRM difference), cross-BLK uses fwa_upstream both directions
+- Wired after frs_cluster in .frs_run_connectivity() when connected_distance_max is set
+- 675 tests pass

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,14 @@
+# Task: connected_distance_max post-cluster filter (#133 reopened)
+
+## Goal
+After frs_cluster finds connected clusters, filter out individual segments whose network distance to the nearest connected habitat segment exceeds `connected_distance_max`. Currently it only controls the cluster search distance, not the extent.
+
+## Status: in progress
+
+## Phases
+- [x] Branch + PWF
+- [x] New `.frs_distance_filter()` — same-BLK DRM distance + cross-BLK ltree check
+- [x] Wired into `.frs_run_connectivity()` after frs_cluster when connected_distance_max set
+- [x] 675 tests pass
+- [ ] Code-check
+- [ ] PR + merge + NEWS + archive


### PR DESCRIPTION
## Summary

Post-cluster distance filter for `connected_distance_max`. The previous implementation (PR #134) passed it as `bridge_distance` to `frs_cluster()` which only controls search distance, not habitat extent.

New `.frs_distance_filter()` runs AFTER `frs_cluster()` and removes individual segments further than `connected_distance_max` from the nearest connected segment:
- Same-BLK: `abs(DRM difference)` — covers the primary SK case (spawning downstream of lake on same stream)
- Cross-BLK: `fwa_upstream` connectivity check in both directions (no distance cap — documented limitation, covers tributary spawning near lakes)

Adams River SK spawning should drop from 112 km toward 74 km (bcfishpass: 74.38 km).

## Test plan

- [x] 675 tests pass
- [x] Code-check: clean (sprintf verified, cross-BLK distance-unbounded noted as documented design choice)

Fixes #133
Relates to NewGraphEnvironment/sred-2025-2026#16
