### PR TITLE
Fix distance filter: remove cross-BLK bypass

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -1205,12 +1205,12 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
       label_cluster, habitat, sp_quoted))$n
   }
 
-  # Remove segments where the nearest connected segment is too far.
-  # Same-BLK: use absolute DRM difference.
-  # Cross-BLK: use fwa_upstream/fwa_downstream path — simplified to
-  # "exists a connected segment within max_distance on any BLK" via
-  # the same-BLK DRM check (covers the primary case: spawning
-  # downstream of a lake on the same stream).
+  # Remove segments where the nearest connected segment on the same
+  # blue_line_key is further than max_distance (via DRM difference).
+  # Cross-BLK distance is not computed — segments with no same-BLK
+  # connected segment within range are removed. This is correct for
+  # the primary case (SK spawning downstream of lake on the same
+  # stream) and conservative for cross-BLK cases.
   .frs_db_execute(conn, sprintf(
     "UPDATE %s h SET %s = FALSE
      FROM %s s
@@ -1222,19 +1222,9 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
          INNER JOIN %s hr ON r.id_segment = hr.id_segment
          WHERE hr.species_code = %s
            AND hr.%s IS TRUE
-           AND (
-             (r.blue_line_key = s.blue_line_key
-              AND abs(r.downstream_route_measure -
-                      s.downstream_route_measure) <= %s)
-             OR
-             (r.blue_line_key != s.blue_line_key
-              AND r.wscode_ltree IS NOT NULL
-              AND s.wscode_ltree IS NOT NULL
-              AND (fwa_upstream(s.wscode_ltree, s.localcode_ltree,
-                               r.wscode_ltree, r.localcode_ltree)
-                   OR fwa_upstream(r.wscode_ltree, r.localcode_ltree,
-                                  s.wscode_ltree, s.localcode_ltree)))
-           )
+           AND r.blue_line_key = s.blue_line_key
+           AND abs(r.downstream_route_measure -
+                   s.downstream_route_measure) <= %s
        )",
     habitat, label_cluster, table,
     sp_quoted, label_cluster,

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,3 @@
+# Findings
+
+Lake rearing (BLK 356000536) ≠ Adams River (BLK 356362743). Cross-BLK fwa_upstream match bypasses distance cap. Fix: same-BLK DRM only.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,5 @@
+# Progress: Issue #133 (third pass)
+
+### 2026-04-12
+- Investigated: Shuswap Lake rearing is on BLK 356000536, Adams River spawning on BLK 356362743. Cross-BLK fwa_upstream match bypasses distance cap.
+- Fix: remove cross-BLK branch from distance filter SQL

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,13 @@
+# Task: Fix distance filter cross-BLK bypass (#133)
+
+## Goal
+Remove the cross-BLK branch from `.frs_distance_filter()` that bypasses the distance cap. Lake rearing on a different BLK was keeping spawning segments 11.7km away alive.
+
+## Status: in progress
+
+## Phases
+- [x] Branch + PWF
+- [x] Remove cross-BLK OR branch — same-BLK DRM only
+- [x] 675 tests pass
+- [ ] Code-check
+- [ ] PR + merge + archive


### PR DESCRIPTION
## Summary

Remove the cross-BLK `fwa_upstream` branch from `.frs_distance_filter()` that bypassed the `connected_distance_max` distance cap. Lake rearing on a different BLK (Shuswap Lake BLK 356000536) was keeping Adams River spawning (BLK 356362743) alive at measure 760 — 11.7km from rearing, with a 3km cap.

Fix: same-BLK DRM distance only. Conservative for cross-BLK cases but correct for the primary SK use case.

## Test plan

- [x] 675 tests pass
- [x] Code-check: clean (sprintf count verified)

Fixes #133
Relates to NewGraphEnvironment/sred-2025-2026#16
