### PR TITLE
Fix distance filter: Euclidean fallback for cross-BLK

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -1205,12 +1205,12 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
       label_cluster, habitat, sp_quoted))$n
   }
 
-  # Remove segments where the nearest connected segment on the same
-  # blue_line_key is further than max_distance (via DRM difference).
-  # Cross-BLK distance is not computed — segments with no same-BLK
-  # connected segment within range are removed. This is correct for
-  # the primary case (SK spawning downstream of lake on the same
-  # stream) and conservative for cross-BLK cases.
+  # Remove segments where the nearest connected segment is further
+  # than max_distance. Two distance measures:
+  #   Same-BLK: abs(DRM difference) — exact network distance.
+  #   Cross-BLK: ST_Distance on geometries — Euclidean approximation.
+  #     Underestimates network distance (straight line < river path)
+  #     so slightly more habitat survives than a true network cap.
   .frs_db_execute(conn, sprintf(
     "UPDATE %s h SET %s = FALSE
      FROM %s s
@@ -1222,15 +1222,20 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
          INNER JOIN %s hr ON r.id_segment = hr.id_segment
          WHERE hr.species_code = %s
            AND hr.%s IS TRUE
-           AND r.blue_line_key = s.blue_line_key
-           AND abs(r.downstream_route_measure -
-                   s.downstream_route_measure) <= %s
+           AND (
+             (r.blue_line_key = s.blue_line_key
+              AND abs(r.downstream_route_measure -
+                      s.downstream_route_measure) <= %s)
+             OR
+             (r.blue_line_key != s.blue_line_key
+              AND ST_Distance(s.geom, r.geom) <= %s)
+           )
        )",
     habitat, label_cluster, table,
     sp_quoted, label_cluster,
     table, habitat,
     sp_quoted, label_connect,
-    dist_m))
+    dist_m, dist_m))
 
   if (verbose) {
     n_after <- DBI::dbGetQuery(conn, sprintf(

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,10 @@
+# Findings
+
+Three attempts:
+1. No distance cap on cross-BLK → 11.7km segment survived
+2. No cross-BLK at all → overcorrected (14.9 km vs 85.7)
+3. This fix: Euclidean ST_Distance for cross-BLK, capped at connected_distance_max
+
+Euclidean is an underestimate of network distance (straight line < river path). For a 3km cap, a segment 3km Euclidean might be 4-5km by stream. This means slightly more spawning survives than bcfishpass (which uses a network-aware approach). But it's much closer than either extreme.
+
+Adams River verification: segment at measure 760 is ~9.3km Euclidean from lake rearing. 9300 > 3000 → removed. Correct.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,7 @@
+# Progress: Issue #133 (fourth pass)
+
+### 2026-04-12
+- PR #137: cross-BLK bypass → 11.7km survived 3km cap
+- PR #138: removed cross-BLK → overcorrected to 14.9 km (bcfishpass: 85.7)
+- Root cause: spawning (stream BLK) and rearing (lake BLK) are always different BLKs for SK
+- Fix: Euclidean ST_Distance fallback for cross-BLK, capped at connected_distance_max

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,18 @@
+# Task: Fix distance filter with cross-BLK Euclidean fallback (#133)
+
+## Goal
+Same-BLK: DRM difference (exact network distance). Cross-BLK: ST_Distance on geometries (Euclidean). Both capped at connected_distance_max.
+
+## Status: in progress
+
+## Why
+- PR #137: cross-BLK had no distance cap → 11.7km segment survived 3km cap
+- PR #138: removed cross-BLK entirely → overcorrected, SK spawning 113→14.9 km (bcfishpass: 85.7)
+- Spawning and rearing are on DIFFERENT BLKs (stream vs lake flow line) — cross-BLK IS the normal case for SK
+
+## Phases
+- [x] Branch + PWF
+- [x] Updated `.frs_distance_filter()`: same-BLK DRM OR cross-BLK ST_Distance
+- [x] 675 tests pass
+- [ ] Code-check
+- [ ] PR + merge + archive


### PR DESCRIPTION
## Summary

Fix the `connected_distance_max` distance filter (fourth attempt on #133).

**History:**
- PR #134: passed as `bridge_distance` — wrong concept (search distance vs extent)
- PR #137: post-cluster filter but cross-BLK had no distance cap → 11.7km segment survived 3km cap
- PR #138: removed cross-BLK entirely → overcorrected, SK spawning 113 → 14.9 km (bcfishpass: 85.7)
- **This PR**: same-BLK DRM difference (exact) OR cross-BLK `ST_Distance` (Euclidean, capped)

Root cause: SK spawning (stream BLK) and rearing (lake BLK) are always on different BLKs. Cross-BLK distance IS the normal case and needs a cap.

Euclidean underestimates network distance (straight line < river path), so slightly more habitat survives than a true network cap. But it correctly removes the Adams River measure 760 segment (9.3km Euclidean from lake rearing > 3km cap).

## Test plan

- [x] 675 tests pass
- [x] Code-check: clean (11 sprintf args verified, ST_Distance uses spatial index)

Fixes #133
Relates to NewGraphEnvironment/sred-2025-2026#16
