### PR TITLE
Fix distance filter: downstream-only cap with correct fwa_upstream direction

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -1235,12 +1235,13 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
               AND s.downstream_route_measure < r.downstream_route_measure
               AND r.downstream_route_measure - s.downstream_route_measure <= %s)
              OR
-             -- Cross-BLK: upstream of rearing (any distance)
+             -- Cross-BLK: spawning upstream of rearing (any distance)
+             -- fwa_upstream(r, s) = TRUE when s is upstream of r
              (r.blue_line_key != s.blue_line_key
               AND s.wscode_ltree IS NOT NULL
               AND r.wscode_ltree IS NOT NULL
-              AND fwa_upstream(s.wscode_ltree, s.localcode_ltree,
-                               r.wscode_ltree, r.localcode_ltree))
+              AND fwa_upstream(r.wscode_ltree, r.localcode_ltree,
+                               s.wscode_ltree, s.localcode_ltree))
              OR
              -- Cross-BLK: downstream, within Euclidean cap
              (r.blue_line_key != s.blue_line_key

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -1205,12 +1205,15 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
       label_cluster, habitat, sp_quoted))$n
   }
 
-  # Remove segments where the nearest connected segment is further
-  # than max_distance. Two distance measures:
-  #   Same-BLK: abs(DRM difference) — exact network distance.
-  #   Cross-BLK: ST_Distance on geometries — Euclidean approximation.
-  #     Underestimates network distance (straight line < river path)
-  #     so slightly more habitat survives than a true network cap.
+  # Remove segments that are DOWNSTREAM of rearing AND beyond the
+  # distance cap. Upstream spawning has no distance cap — limited by
+  # spawn-eligible contiguity (matching bcfishpass v0.5.0 SK logic).
+  #
+  # A segment is kept if ANY rearing segment satisfies:
+  #   Same-BLK upstream: s.drm >= r.drm (segment above rearing, any distance)
+  #   Same-BLK downstream within cap: s.drm < r.drm AND diff <= max
+  #   Cross-BLK upstream: fwa_upstream(s, r) (rearing is upstream, any distance)
+  #   Cross-BLK downstream within cap: NOT upstream AND Euclidean <= max
   .frs_db_execute(conn, sprintf(
     "UPDATE %s h SET %s = FALSE
      FROM %s s
@@ -1223,10 +1226,23 @@ frs_habitat_species <- function(conn, species_code, base_tbl, breaks,
          WHERE hr.species_code = %s
            AND hr.%s IS TRUE
            AND (
+             -- Same-BLK: upstream of rearing (any distance)
              (r.blue_line_key = s.blue_line_key
-              AND abs(r.downstream_route_measure -
-                      s.downstream_route_measure) <= %s)
+              AND s.downstream_route_measure >= r.downstream_route_measure)
              OR
+             -- Same-BLK: downstream of rearing, within cap
+             (r.blue_line_key = s.blue_line_key
+              AND s.downstream_route_measure < r.downstream_route_measure
+              AND r.downstream_route_measure - s.downstream_route_measure <= %s)
+             OR
+             -- Cross-BLK: upstream of rearing (any distance)
+             (r.blue_line_key != s.blue_line_key
+              AND s.wscode_ltree IS NOT NULL
+              AND r.wscode_ltree IS NOT NULL
+              AND fwa_upstream(s.wscode_ltree, s.localcode_ltree,
+                               r.wscode_ltree, r.localcode_ltree))
+             OR
+             -- Cross-BLK: downstream, within Euclidean cap
              (r.blue_line_key != s.blue_line_key
               AND ST_Distance(s.geom, r.geom) <= %s)
            )

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,38 @@
+# Findings
+
+bcfishpass SK spawning:
+- Downstream from lake: 3km cap, 5% gradient bridge, mainstem only
+- Upstream of lake: NO distance cap, limited by spawn eligibility contiguity
+
+The distance filter must only remove segments where:
+1. The segment IS downstream of rearing (rearing is upstream of the segment)
+2. AND the distance exceeds connected_distance_max
+
+"Downstream of rearing" means rearing is above the segment:
+- Same-BLK: s.drm < r.drm (segment measure below rearing measure)  
+- Cross-BLK: fwa_upstream(s, r) — rearing is upstream of segment
+
+Segments where the segment IS upstream of rearing (s.drm >= r.drm, or segment is upstream via ltree) are KEPT with no distance cap.
+
+SQL logic for NOT EXISTS (keep if):
+```sql
+-- Keep if: upstream of rearing (any distance)
+(r.blue_line_key = s.blue_line_key
+ AND s.downstream_route_measure >= r.downstream_route_measure)
+OR
+-- Keep if: downstream of rearing but within cap
+(r.blue_line_key = s.blue_line_key
+ AND s.downstream_route_measure < r.downstream_route_measure
+ AND r.downstream_route_measure - s.downstream_route_measure <= max_dist)
+OR
+-- Keep if: cross-BLK upstream of rearing (any distance)
+(r.blue_line_key != s.blue_line_key
+ AND fwa_upstream(s.wscode_ltree, s.localcode_ltree,
+                  r.wscode_ltree, r.localcode_ltree))
+OR
+-- Keep if: cross-BLK downstream within Euclidean cap
+(r.blue_line_key != s.blue_line_key
+ AND NOT fwa_upstream(s.wscode_ltree, s.localcode_ltree,
+                      r.wscode_ltree, r.localcode_ltree)
+ AND ST_Distance(s.geom, r.geom) <= max_dist)
+```

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,5 @@
+# Progress: Issue #133 (corrected prompt)
+
+### 2026-04-12
+- Branch `133-downstream-only-distance` created
+- Previous attempts: bidirectional cap → overcorrection. Need downstream-only.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,22 @@
+# Task: Distance cap downstream only (#133, corrected)
+
+## Goal
+connected_distance_max applies ONLY to spawning segments that are DOWNSTREAM of the nearest rearing. Upstream spawning has no distance cap — limited only by spawn-eligible contiguity.
+
+## Key insight
+A segment is "downstream of rearing" when rearing is UPSTREAM of it:
+- Same-BLK: `s.drm < r.drm` (segment is below rearing on the stream)
+- Cross-BLK: `fwa_upstream(s.ws, s.lc, r.ws, r.lc)` (rearing is upstream of segment)
+
+The filter removes spawning segments where:
+- The nearest rearing is upstream (segment is downstream of rearing)
+- AND the distance to that rearing > connected_distance_max
+
+Segments where rearing is downstream or lateral (segment is upstream of rearing) are KEPT regardless of distance.
+
+## Phases
+- [x] Branch + PWF
+- [x] Rewrite `.frs_distance_filter()` — directional: upstream unlimited, downstream capped
+- [x] 675 tests pass
+- [ ] Code-check
+- [ ] PR + merge + archive


### PR DESCRIPTION
## Summary

`connected_distance_max` now correctly applies as a **downstream-only** cap, matching bcfishpass v0.5.0 SK spawning logic:

- **Upstream of rearing**: no distance cap — limited by spawn-eligible contiguity
- **Downstream of rearing**: capped at `connected_distance_max`

Direction detection:
- Same-BLK: `s.drm >= r.drm` = upstream (keep), `s.drm < r.drm` = downstream (cap)
- Cross-BLK: `fwa_upstream(r, s)` = spawning upstream of rearing (keep), else Euclidean cap

Expected Adams River ADMS result:
- Downstream of lake (< measure 12,456): ~1.7 km (3km cap)
- Upstream of lake (> measure ~75,233): ~72 km (no cap, contiguity-limited)
- Total: ~74 km (bcfishpass: 74.38 km)

## Test plan

- [x] 675 tests pass
- [x] Code-check: found `fwa_upstream` arg swap (s,r vs r,s). Fixed.

Fixes #133
Relates to NewGraphEnvironment/sred-2025-2026#16
