### PR TITLE
Add to_barriers parameter for persisting gradient barriers

### DIFF
--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -52,6 +52,12 @@
 #'   gradient from DEM vertices after splitting segments. If `FALSE`,
 #'   child segments inherit the parent gradient. See
 #'   [frs_network_segment()] for details.
+#' @param to_barriers Character or `NULL`. Schema-qualified table for
+#'   persisting gradient barriers. Includes `blue_line_key`,
+#'   `downstream_route_measure`, `gradient_class`, `label`,
+#'   `wscode_ltree`, `localcode_ltree`. Useful for link's
+#'   `lnk_barrier_overrides()`. Default `NULL` (barriers dropped after
+#'   segmentation).
 #' @param barrier_overrides Character or `NULL`. Schema-qualified table
 #'   of barrier overrides prepared by link via
 #'   `lnk_barrier_overrides()`. Must have columns `blue_line_key`,
@@ -191,6 +197,7 @@ frs_habitat <- function(conn, wsg = NULL,
                         gradient_recompute = TRUE,
                         measure_precision = 0L,
                         barrier_overrides = NULL,
+                        to_barriers = NULL,
                         params = NULL,
                         params_fresh = NULL,
                         workers = 1L,
@@ -309,7 +316,8 @@ frs_habitat <- function(conn, wsg = NULL,
   # -- Per-job worker function -------------------------------------------------
   .run_job <- function(spec, conn_params, break_sources, breaks_gradient,
                        gradient_recompute, measure_precision, params,
-                       params_fresh, to_streams, to_habitat, verbose) {
+                       params_fresh, to_streams, to_habitat, to_barriers,
+                       verbose) {
     # Connect (parallel) or reuse (sequential)
     if (!is.null(conn_params)) {
       library(fresh)
@@ -470,6 +478,24 @@ frs_habitat <- function(conn, wsg = NULL,
         to_streams, streams_tbl))
     }
 
+    # 5b. Persist gradient barriers (if to_barriers provided)
+    if (!is.null(to_barriers)) {
+      # Enrich with ltree before persisting
+      .frs_enrich_breaks(w_conn, grad_tbl)
+      .frs_db_execute(w_conn, sprintf(
+        "CREATE TABLE IF NOT EXISTS %s AS SELECT * FROM %s LIMIT 0",
+        to_barriers, grad_tbl))
+      if (!is.null(wsg_code)) {
+        .frs_db_execute(w_conn, sprintf(
+          "DELETE FROM %s WHERE blue_line_key IN (
+             SELECT DISTINCT blue_line_key FROM %s)",
+          to_barriers, grad_tbl))
+      }
+      .frs_db_execute(w_conn, sprintf(
+        "INSERT INTO %s SELECT * FROM %s",
+        to_barriers, grad_tbl))
+    }
+
     # 6. Cleanup working tables
     .frs_db_execute(w_conn, sprintf(
       "DROP TABLE IF EXISTS %s", paste0(streams_tbl, "_breaks")))
@@ -610,6 +636,23 @@ frs_habitat <- function(conn, wsg = NULL,
           "INSERT INTO %s SELECT * FROM %s", to_streams, streams_tbl))
       }
 
+      # Persist gradient barriers
+      if (!is.null(to_barriers)) {
+        .frs_enrich_breaks(w_conn, grad_tbl)
+        DBI::dbExecute(w_conn, sprintf(
+          "CREATE TABLE IF NOT EXISTS %s AS SELECT * FROM %s LIMIT 0",
+          to_barriers, grad_tbl))
+        if (!is.null(wsg_code)) {
+          DBI::dbExecute(w_conn, sprintf(
+            "DELETE FROM %s WHERE blue_line_key IN (
+               SELECT DISTINCT blue_line_key FROM %s)",
+            to_barriers, grad_tbl))
+        }
+        DBI::dbExecute(w_conn, sprintf(
+          "INSERT INTO %s SELECT * FROM %s",
+          to_barriers, grad_tbl))
+      }
+
       DBI::dbExecute(w_conn, sprintf(
         "DROP TABLE IF EXISTS %s", paste0(streams_tbl, "_breaks")))
       for (tbl in barrier_tables) {
@@ -630,7 +673,7 @@ frs_habitat <- function(conn, wsg = NULL,
       measure_precision = measure_precision,
       barrier_overrides = barrier_overrides,
       params = params, params_fresh = params_fresh,
-      to_streams = to_streams, to_habitat = to_habitat,
+      to_streams = to_streams, to_habitat = to_habitat, to_barriers = to_barriers,
       gate = gate, label_block = label_block,
       verbose = verbose)[]
 
@@ -650,7 +693,7 @@ frs_habitat <- function(conn, wsg = NULL,
         gradient_recompute = gradient_recompute,
         measure_precision = measure_precision,
         params = params, params_fresh = params_fresh,
-        to_streams = to_streams, to_habitat = to_habitat,
+        to_streams = to_streams, to_habitat = to_habitat, to_barriers = to_barriers,
         verbose = verbose)
       if (verbose) {
         cat("  ", res$label, ": ", res$n_segments, " segs, ",

--- a/R/frs_habitat.R
+++ b/R/frs_habitat.R
@@ -485,12 +485,11 @@ frs_habitat <- function(conn, wsg = NULL,
       .frs_db_execute(w_conn, sprintf(
         "CREATE TABLE IF NOT EXISTS %s AS SELECT * FROM %s LIMIT 0",
         to_barriers, grad_tbl))
-      if (!is.null(wsg_code)) {
-        .frs_db_execute(w_conn, sprintf(
-          "DELETE FROM %s WHERE blue_line_key IN (
-             SELECT DISTINCT blue_line_key FROM %s)",
-          to_barriers, grad_tbl))
-      }
+      # Idempotent delete by BLK (works for both WSG and custom AOI)
+      .frs_db_execute(w_conn, sprintf(
+        "DELETE FROM %s WHERE blue_line_key IN (
+           SELECT DISTINCT blue_line_key FROM %s)",
+        to_barriers, grad_tbl))
       .frs_db_execute(w_conn, sprintf(
         "INSERT INTO %s SELECT * FROM %s",
         to_barriers, grad_tbl))
@@ -642,12 +641,10 @@ frs_habitat <- function(conn, wsg = NULL,
         DBI::dbExecute(w_conn, sprintf(
           "CREATE TABLE IF NOT EXISTS %s AS SELECT * FROM %s LIMIT 0",
           to_barriers, grad_tbl))
-        if (!is.null(wsg_code)) {
-          DBI::dbExecute(w_conn, sprintf(
-            "DELETE FROM %s WHERE blue_line_key IN (
-               SELECT DISTINCT blue_line_key FROM %s)",
-            to_barriers, grad_tbl))
-        }
+        DBI::dbExecute(w_conn, sprintf(
+          "DELETE FROM %s WHERE blue_line_key IN (
+             SELECT DISTINCT blue_line_key FROM %s)",
+          to_barriers, grad_tbl))
         DBI::dbExecute(w_conn, sprintf(
           "INSERT INTO %s SELECT * FROM %s",
           to_barriers, grad_tbl))

--- a/man/frs_habitat.Rd
+++ b/man/frs_habitat.Rd
@@ -20,6 +20,7 @@ frs_habitat(
   gradient_recompute = TRUE,
   measure_precision = 0L,
   barrier_overrides = NULL,
+  to_barriers = NULL,
   params = NULL,
   params_fresh = NULL,
   workers = 1L,
@@ -98,6 +99,13 @@ of barrier overrides prepared by link via
 \code{downstream_route_measure}, \code{species_code}. When provided,
 matched barriers are excluded from per-species access gating.
 Default \code{NULL} (no overrides).}
+
+\item{to_barriers}{Character or \code{NULL}. Schema-qualified table for
+persisting gradient barriers. Includes \code{blue_line_key},
+\code{downstream_route_measure}, \code{gradient_class}, \code{label},
+\code{wscode_ltree}, \code{localcode_ltree}. Useful for link's
+\code{lnk_barrier_overrides()}. Default \code{NULL} (barriers dropped after
+segmentation).}
 
 \item{params}{Named list from \code{\link[=frs_params]{frs_params()}}, or \code{NULL} to use
 bundled \code{parameters_habitat_thresholds.csv} and rules YAML.}

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,9 @@
+# Findings
+
+grad_tbl is created at line 400 (sequential) / 557 (mirai), enriched with label column, then added to barrier_tables. At cleanup (line 476/615), all barrier_tables are dropped.
+
+Fix: before the cleanup loop, if to_barriers is provided, INSERT INTO to_barriers SELECT * FROM grad_tbl. The grad_tbl already has wscode_ltree and localcode_ltree from .frs_enrich_breaks() which runs on the breaks table (but NOT on grad_tbl directly — it runs on breaks_tbl which is the merged breaks table from frs_network_segment).
+
+Wait — the grad_tbl is the RAW output from frs_break_find(). It has: blue_line_key, downstream_route_measure, gradient_class, label, source. It does NOT have wscode_ltree/localcode_ltree — those are added by .frs_enrich_breaks() which operates on the breaks_tbl (the merged table inside frs_network_segment).
+
+Need to enrich grad_tbl with ltree columns before persisting. Can use the same .frs_enrich_breaks() helper.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,4 @@
+# Progress: Issue #143
+
+### 2026-04-12
+- Branch created, PWF initialized

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,12 @@
+# Task: to_barriers parameter (#143)
+
+## Goal
+Persist the gradient barriers table when `to_barriers` is provided. Currently dropped after segmentation.
+
+## Phases
+- [x] Branch + PWF
+- [x] `to_barriers` param — persist grad_tbl with ltree enrichment before cleanup
+- [x] Both sequential + mirai branches
+- [x] 2 integration tests (persist + NULL), 690 total pass
+- [ ] Code-check
+- [ ] PR + merge + archive

--- a/tests/testthat/test-frs_habitat.R
+++ b/tests/testthat/test-frs_habitat.R
@@ -254,3 +254,73 @@ test_that("integration: wsg + aoi does not scan entire province", {
   expect_lt(n, 15000)
   expect_gt(n, 5000)
 })
+
+# --- Integration tests: to_barriers parameter ---
+
+test_that("integration: to_barriers persists gradient barriers table", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+
+  aoi <- "wscode_ltree <@ '100.190442.999098.995997.058910.432966'::ltree"
+
+  on.exit({
+    for (tbl in c("working.persist_barriers_143",
+                  "working.persist_barriers_143_s",
+                  "working.persist_barriers_143_h")) {
+      DBI::dbExecute(conn, sprintf("DROP TABLE IF EXISTS %s CASCADE", tbl))
+    }
+    DBI::dbDisconnect(conn)
+  })
+
+  frs_habitat(conn,
+    aoi = aoi, species = "BT", label = "b143",
+    to_streams = "working.persist_barriers_143_s",
+    to_habitat = "working.persist_barriers_143_h",
+    to_barriers = "working.persist_barriers_143",
+    verbose = FALSE)
+
+  # Barriers table should exist and have rows
+  n <- DBI::dbGetQuery(conn,
+    "SELECT count(*)::int AS n FROM working.persist_barriers_143")$n
+  expect_gt(n, 0)
+
+  # Should have expected columns
+  cols <- DBI::dbGetQuery(conn,
+    "SELECT column_name FROM information_schema.columns
+     WHERE table_schema = 'working' AND table_name = 'persist_barriers_143'
+     ORDER BY ordinal_position")$column_name
+  expect_true("blue_line_key" %in% cols)
+  expect_true("downstream_route_measure" %in% cols)
+  expect_true("gradient_class" %in% cols)
+  expect_true("label" %in% cols)
+  expect_true("wscode_ltree" %in% cols)
+  expect_true("localcode_ltree" %in% cols)
+})
+
+test_that("integration: NULL to_barriers does not persist", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+
+  aoi <- "wscode_ltree <@ '100.190442.999098.995997.058910.432966'::ltree"
+
+  on.exit({
+    DBI::dbExecute(conn, "DROP TABLE IF EXISTS working.persist_null_143_s CASCADE")
+    DBI::dbExecute(conn, "DROP TABLE IF EXISTS working.persist_null_143_h CASCADE")
+    DBI::dbDisconnect(conn)
+  })
+
+  frs_habitat(conn,
+    aoi = aoi, species = "BT", label = "n143",
+    to_streams = "working.persist_null_143_s",
+    to_habitat = "working.persist_null_143_h",
+    to_barriers = NULL,
+    verbose = FALSE)
+
+  # No barriers table should exist
+  exists <- DBI::dbGetQuery(conn,
+    "SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'working' AND table_name = 'barriers_n143_gradient'
+     ) AS e")$e
+  expect_false(exists)
+})


### PR DESCRIPTION
## Summary

- `to_barriers` parameter on `frs_habitat()` — persist gradient barriers table with ltree enrichment before cleanup. Includes `blue_line_key`, `downstream_route_measure`, `gradient_class`, `label`, `wscode_ltree`, `localcode_ltree`.
- Idempotent BLK-based delete on re-run (works for both WSG and custom AOI modes)
- Useful for link's `lnk_barrier_overrides()` which needs the full barriers table

## Test plan

- [x] 2 integration tests: persist with columns check + NULL does not persist
- [x] 690 tests pass
- [x] Code-check: found missing idempotent delete for custom AOI mode. Fixed.

Fixes #143
Relates to NewGraphEnvironment/sred-2025-2026#16
