### PR TITLE
Preserve multiple labels per break position

### DIFF
--- a/R/frs_network_segment.R
+++ b/R/frs_network_segment.R
@@ -187,12 +187,15 @@ frs_network_segment <- function(conn, aoi, to,
       "UPDATE %s SET downstream_route_measure =
          round(downstream_route_measure::numeric, %d)",
       breaks_tbl, mp))
-    # Remove duplicates at the same rounded position on same BLK
+    # Remove exact duplicates (same position AND same label).
+    # Different labels at the same position are preserved — a gradient_15
+    # and a falls at the same measure both survive in the breaks table.
     .frs_db_execute(conn, sprintf(
       "DELETE FROM %s a USING %s b
        WHERE a.ctid > b.ctid
          AND a.blue_line_key = b.blue_line_key
-         AND a.downstream_route_measure = b.downstream_route_measure",
+         AND a.downstream_route_measure = b.downstream_route_measure
+         AND a.label = b.label",
       breaks_tbl, breaks_tbl))
 
     # Enrich breaks with ltree for classify + index

--- a/R/frs_network_segment.R
+++ b/R/frs_network_segment.R
@@ -195,7 +195,7 @@ frs_network_segment <- function(conn, aoi, to,
        WHERE a.ctid > b.ctid
          AND a.blue_line_key = b.blue_line_key
          AND a.downstream_route_measure = b.downstream_route_measure
-         AND a.label = b.label",
+         AND a.label IS NOT DISTINCT FROM b.label",
       breaks_tbl, breaks_tbl))
 
     # Enrich breaks with ltree for classify + index

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,3 @@
+# Findings
+
+The dedup at line 191-196 uses (BLK, DRM) only. Two labels at the same position lose one. Fix: add label to the dedup key. frs_break_apply already handles geometry dedup separately (SELECT DISTINCT BLK, round(DRM) — no label involved).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,5 @@
+# Progress: Issue #145
+
+### 2026-04-12
+- Branch created, PWF initialized
+- Found root cause: line 191-196 in frs_network_segment.R deduplicates on (BLK, DRM) only

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,18 @@
+# Task: Preserve multiple labels per break position (#145)
+
+## Goal
+Allow multiple labels at the same (BLK, DRM) position in streams_breaks. A gradient_15 and a falls at the same measure should both survive.
+
+## Root cause
+frs_network_segment.R line 191-196: DELETE deduplicates on (blue_line_key, downstream_route_measure) only. Drops one label when two break sources share a position.
+
+## Fix
+Add `AND a.label = b.label` to only dedup truly identical rows. Different labels at the same position are preserved.
+
+## Phases
+- [x] Branch + PWF
+- [x] Fix dedup: add `AND a.label = b.label` to only remove exact duplicates
+- [x] Integration test: two mock break sources at same position, verify both labels survive
+- [x] 692 tests pass
+- [ ] Code-check
+- [ ] PR + merge + archive

--- a/tests/testthat/test-frs_habitat.R
+++ b/tests/testthat/test-frs_habitat.R
@@ -324,3 +324,57 @@ test_that("integration: NULL to_barriers does not persist", {
      ) AS e")$e
   expect_false(exists)
 })
+
+# --- Integration tests: multiple labels per break position (#145) ---
+
+test_that("integration: multiple labels at same position preserved in breaks", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+
+  aoi <- "wscode_ltree <@ '100.190442.999098.995997.058910.432966'::ltree"
+  tbl_s <- "working.test_145_streams"
+  tbl_breaks <- paste0(tbl_s, "_breaks")
+
+  on.exit({
+    for (tbl in c(tbl_s, tbl_breaks,
+                  "working.test_145_src_a", "working.test_145_src_b")) {
+      DBI::dbExecute(conn, sprintf("DROP TABLE IF EXISTS %s CASCADE", tbl))
+    }
+    DBI::dbDisconnect(conn)
+  })
+
+  # Extract to get a real BLK + measure
+  frs_extract(conn,
+    from = "whse_basemapping.fwa_stream_networks_sp",
+    to = tbl_s, where = aoi, overwrite = TRUE)
+  pos <- DBI::dbGetQuery(conn, sprintf(
+    "SELECT blue_line_key, downstream_route_measure + 100 AS drm
+     FROM %s LIMIT 1", tbl_s))
+
+  # Create two mock break sources at the SAME position, DIFFERENT labels
+  for (tbl in c("working.test_145_src_a", "working.test_145_src_b")) {
+    DBI::dbExecute(conn, sprintf("DROP TABLE IF EXISTS %s", tbl))
+    DBI::dbExecute(conn, sprintf(
+      "CREATE TABLE %s AS SELECT %d::int AS blue_line_key, %s::float8 AS downstream_route_measure",
+      tbl, pos$blue_line_key, pos$drm))
+  }
+
+  # Segment with both sources at same position
+  DBI::dbExecute(conn, sprintf("DROP TABLE IF EXISTS %s", tbl_s))
+  frs_network_segment(conn, aoi = aoi, to = tbl_s,
+    break_sources = list(
+      list(table = "working.test_145_src_a", label = "label_a"),
+      list(table = "working.test_145_src_b", label = "label_b")),
+    verbose = FALSE)
+
+  # Both labels should survive at the same position
+  dupes <- DBI::dbGetQuery(conn, sprintf(
+    "SELECT blue_line_key, downstream_route_measure,
+            count(DISTINCT label)::int AS n_labels
+     FROM %s
+     GROUP BY blue_line_key, downstream_route_measure
+     HAVING count(DISTINCT label) > 1", tbl_breaks))
+
+  expect_gt(nrow(dupes), 0)
+  expect_true(all(dupes$n_labels >= 2))
+})


### PR DESCRIPTION
## Summary

Preserve multiple labels per break position in `streams_breaks`. A gradient_15 and a falls at the same measure both survive — enabling per-barrier overrides, access reporting, and habitat reporting by barrier type.

- Fix: dedup only removes exact duplicates (same position AND same label), not different labels sharing a position
- Uses `IS NOT DISTINCT FROM` for NULL-safe label comparison (code-check caught NULL bypass)
- Geometry splitting already deduplicates separately in `frs_break_apply` (no label involved)

## Test plan

- [x] Integration test: two mock break sources at same position, verify both labels survive
- [x] 692 tests pass
- [x] Code-check: found NULL label bypass with `=` operator. Fixed with `IS NOT DISTINCT FROM`.

Fixes #145
Relates to NewGraphEnvironment/sred-2025-2026#16
