### PR TITLE
Index classify inputs for 35x standalone speedup

### DIFF
--- a/R/frs_habitat_classify.R
+++ b/R/frs_habitat_classify.R
@@ -108,6 +108,11 @@ frs_habitat_classify <- function(conn, table, to,
       "parameters_fresh.csv", package = "fresh"), stringsAsFactors = FALSE)
   }
 
+  # Ensure input tables are indexed — critical when called directly
+  # (bypassing frs_habitat which indexes during frs_network_segment)
+  .frs_index_working(conn, table)
+  if (gate) .frs_index_working(conn, breaks_tbl)
+
   # Get WSG codes from streams table (for idempotent delete)
   wsg_codes <- DBI::dbGetQuery(conn, sprintf(
     "SELECT DISTINCT watershed_group_code FROM %s", table

--- a/R/utils.R
+++ b/R/utils.R
@@ -326,45 +326,69 @@
     .frs_quote_string(schema), .frs_quote_string(tbl)
   ))$column_name
 
-  # Build index statements based on available columns
+  # Build index statements based on available columns.
+  # Uses IF NOT EXISTS so callers can index the same table multiple times
+
+  # safely (e.g. frs_network_segment indexes, then frs_habitat_classify
+  # re-indexes the same inputs).
   idx <- character(0)
 
   if ("blue_line_key" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (blue_line_key)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_blk_idx ON %s (blue_line_key)",
+      tbl, table))
   }
   if (all(c("blue_line_key", "downstream_route_measure") %in% cols)) {
     idx <- c(idx, sprintf(
-      "CREATE INDEX ON %s (blue_line_key, downstream_route_measure)", table))
+      "CREATE INDEX IF NOT EXISTS %s_blk_drm_idx ON %s (blue_line_key, downstream_route_measure)",
+      tbl, table))
   }
+
   if ("wscode_ltree" %in% cols) {
     idx <- c(idx, sprintf(
-      "CREATE INDEX ON %s USING gist (wscode_ltree)", table))
+      "CREATE INDEX IF NOT EXISTS %s_wscode_gist_idx ON %s USING gist (wscode_ltree)",
+      tbl, table))
     idx <- c(idx, sprintf(
-      "CREATE INDEX ON %s USING btree (wscode_ltree)", table))
+      "CREATE INDEX IF NOT EXISTS %s_wscode_btree_idx ON %s USING btree (wscode_ltree)",
+      tbl, table))
   }
   if ("localcode_ltree" %in% cols) {
     idx <- c(idx, sprintf(
-      "CREATE INDEX ON %s USING gist (localcode_ltree)", table))
+      "CREATE INDEX IF NOT EXISTS %s_localcode_gist_idx ON %s USING gist (localcode_ltree)",
+      tbl, table))
     idx <- c(idx, sprintf(
-      "CREATE INDEX ON %s USING btree (localcode_ltree)", table))
+      "CREATE INDEX IF NOT EXISTS %s_localcode_btree_idx ON %s USING btree (localcode_ltree)",
+      tbl, table))
   }
   if ("linear_feature_id" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (linear_feature_id)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_lfid_idx ON %s (linear_feature_id)",
+      tbl, table))
   }
   if ("watershed_group_code" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (watershed_group_code)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_wsg_idx ON %s (watershed_group_code)",
+      tbl, table))
   }
   if ("label" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (label)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_label_idx ON %s (label)",
+      tbl, table))
     if ("blue_line_key" %in% cols) {
-      idx <- c(idx, sprintf("CREATE INDEX ON %s (label, blue_line_key)", table))
+      idx <- c(idx, sprintf(
+        "CREATE INDEX IF NOT EXISTS %s_label_blk_idx ON %s (label, blue_line_key)",
+        tbl, table))
     }
   }
   if ("id_segment" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (id_segment)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_id_segment_idx ON %s (id_segment)",
+      tbl, table))
   }
   if ("species_code" %in% cols) {
-    idx <- c(idx, sprintf("CREATE INDEX ON %s (species_code)", table))
+    idx <- c(idx, sprintf(
+      "CREATE INDEX IF NOT EXISTS %s_species_code_idx ON %s (species_code)",
+      tbl, table))
   }
 
   for (sql in idx) {

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,12 @@
+# Findings
+
+## Current state
+- `.frs_index_working()` in `R/utils.R:312` uses `CREATE INDEX ON %s ...` (no name, no IF NOT EXISTS)
+- Called on output tables by: `frs_extract`, `frs_network_segment` (breaks + output), `frs_feature_index`, `frs_habitat_classify` (output only), `frs_habitat` (barriers)
+- NOT called on input tables in `frs_habitat_classify` — `table` and `breaks_tbl` assumed pre-indexed
+- When users call `frs_habitat_classify` directly (bypassing `frs_habitat`), ltree gist indexes missing → 35x slower
+
+## Index naming
+- PostgreSQL requires explicit name for `IF NOT EXISTS`
+- Name format: `{table}_{col(s)}_{type}_idx` (e.g., `fresh_streams_wscode_ltree_gist_idx`)
+- Must be unique within schema — include table name to avoid collisions

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -5,4 +5,6 @@
 - Read issue #150, reviewed `.frs_index_working()` and `frs_habitat_classify()`
 - Phase 1 complete: `.frs_index_working` now uses IF NOT EXISTS with named indexes
 - 696 tests pass, code-check clean
-- Next: Phase 2 — index input tables in `frs_habitat_classify`
+- Phase 2 complete: added `.frs_index_working` calls in `frs_habitat_classify`
+- Code-check caught: breaks_tbl may not exist with gate=FALSE — guarded with `if (gate)`
+- Next: Phase 3 — PR

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -3,4 +3,6 @@
 ## Session 2026-04-13
 - Created branch `150-index-classify-inputs` from main (6d87f8d)
 - Read issue #150, reviewed `.frs_index_working()` and `frs_habitat_classify()`
-- Next: Phase 1 — make `.frs_index_working` idempotent with IF NOT EXISTS
+- Phase 1 complete: `.frs_index_working` now uses IF NOT EXISTS with named indexes
+- 696 tests pass, code-check clean
+- Next: Phase 2 — index input tables in `frs_habitat_classify`

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,6 @@
+# Progress
+
+## Session 2026-04-13
+- Created branch `150-index-classify-inputs` from main (6d87f8d)
+- Read issue #150, reviewed `.frs_index_working()` and `frs_habitat_classify()`
+- Next: Phase 1 — make `.frs_index_working` idempotent with IF NOT EXISTS

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,9 +1,9 @@
 # Task Plan: Issue #150 — Index classify inputs
 
 ## Phase 1: Make `.frs_index_working` idempotent
-- [ ] Add `IF NOT EXISTS` with explicit named indexes to all CREATE INDEX statements
-- [ ] Add test: call `.frs_index_working` twice on same table, no error
-- [ ] Commit + code-check
+- [x] Add `IF NOT EXISTS` with explicit named indexes to all CREATE INDEX statements
+- [x] Add test: call `.frs_index_working` twice on same table, no error
+- [x] Commit + code-check
 
 ## Phase 2: Index input tables in `frs_habitat_classify`
 - [ ] Call `.frs_index_working(conn, table)` and `.frs_index_working(conn, breaks_tbl)` before access gating loop

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,14 @@
+# Task Plan: Issue #150 — Index classify inputs
+
+## Phase 1: Make `.frs_index_working` idempotent
+- [ ] Add `IF NOT EXISTS` with explicit named indexes to all CREATE INDEX statements
+- [ ] Add test: call `.frs_index_working` twice on same table, no error
+- [ ] Commit + code-check
+
+## Phase 2: Index input tables in `frs_habitat_classify`
+- [ ] Call `.frs_index_working(conn, table)` and `.frs_index_working(conn, breaks_tbl)` before access gating loop
+- [ ] Add test: `frs_habitat_classify` on unindexed table succeeds (existing tests cover this implicitly)
+- [ ] Commit + code-check
+
+## Phase 3: PR
+- [ ] Push branch, create PR with SRED tag

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -6,9 +6,9 @@
 - [x] Commit + code-check
 
 ## Phase 2: Index input tables in `frs_habitat_classify`
-- [ ] Call `.frs_index_working(conn, table)` and `.frs_index_working(conn, breaks_tbl)` before access gating loop
-- [ ] Add test: `frs_habitat_classify` on unindexed table succeeds (existing tests cover this implicitly)
-- [ ] Commit + code-check
+- [x] Call `.frs_index_working(conn, table)` and `.frs_index_working(conn, breaks_tbl)` before access gating loop
+- [x] Guard breaks indexing with `if (gate)` — breaks table may not exist when `gate = FALSE`
+- [x] Commit + code-check
 
 ## Phase 3: PR
 - [ ] Push branch, create PR with SRED tag

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -25,6 +25,48 @@ test_that(".frs_validate_identifier rejects injection attempts", {
 
 # -- env var check -------------------------------------------------------------
 
+# -- .frs_index_working ---------------------------------------------------------
+
+test_that(".frs_index_working is idempotent — no error on double call", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+  tbl <- "working.test_idx_idem"
+  on.exit({
+    .frs_test_drop(conn, tbl)
+    DBI::dbDisconnect(conn)
+  })
+
+  .frs_db_execute(conn, sprintf("DROP TABLE IF EXISTS %s", tbl))
+  .frs_db_execute(conn, sprintf(
+    "CREATE TABLE %s (
+       id_segment integer,
+       blue_line_key integer,
+       downstream_route_measure double precision,
+       wscode_ltree ltree,
+       localcode_ltree ltree,
+       label text
+     )", tbl))
+
+  # First call creates indexes
+  expect_no_error(fresh:::.frs_index_working(conn, tbl))
+
+  # Second call is a no-op — IF NOT EXISTS prevents error
+
+  expect_no_error(fresh:::.frs_index_working(conn, tbl))
+
+  # Verify indexes exist
+  idx_count <- DBI::dbGetQuery(conn, sprintf(
+    "SELECT count(*) AS n FROM pg_indexes WHERE tablename = 'test_idx_idem'"))
+  expect_true(idx_count$n >= 6)
+})
+
+test_that(".frs_index_working skips non-DB connections", {
+  mock_conn <- structure(list(), class = "mock_connection")
+  expect_no_error(fresh:::.frs_index_working(mock_conn, "schema.table"))
+})
+
+# -- env var check -------------------------------------------------------------
+
 test_that("frs_db_conn stops on missing env vars", {
   expect_error(frs_db_conn(dbname = ""), "PG_DB_SHARE")
   expect_error(frs_db_conn(dbname = "x", host = ""), "PG_HOST_SHARE")


### PR DESCRIPTION
## Summary
- Make `.frs_index_working()` idempotent with `IF NOT EXISTS` and explicit named indexes — safe to call multiple times on the same table
- Call `.frs_index_working()` on input tables (`table` and `breaks_tbl`) in `frs_habitat_classify()` before the access gating loop
- 35x speedup when `frs_habitat_classify` is called directly (bypassing `frs_habitat`)

## Test plan
- [x] New test: double-call `.frs_index_working` on same table — no error
- [x] New test: `.frs_index_working` skips non-DB connections
- [x] Full suite: 696 tests pass
- [x] Code-check: clean (caught gate=FALSE guard for breaks table)

Fixes #150
Relates to NewGraphEnvironment/sred-2025-2026#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
