### PR TITLE
Add wetland_rearing column to frs_habitat_classify output

### DIFF
--- a/R/frs_habitat_classify.R
+++ b/R/frs_habitat_classify.R
@@ -2,9 +2,9 @@
 #'
 #' Fish-habitat convenience wrapper. Classifies segments in a segmented
 #' stream network for one or more species into a fixed output schema of
-#' `accessible / spawning / rearing / lake_rearing` booleans keyed by
-#' `species_code`. Produces long-format output: one row per segment x
-#' species.
+#' `accessible / spawning / rearing / lake_rearing / wetland_rearing`
+#' booleans keyed by `species_code`. Produces long-format output: one
+#' row per segment x species.
 #'
 #' For non-fish domains — thermal refugia, riparian connectivity,
 #' sediment-transport models, any classification that doesn't fit the
@@ -86,7 +86,7 @@
 #' # Join geometry back for mapping — id_segment links the two tables
 #' DBI::dbExecute(conn, "
 #'   CREATE OR REPLACE VIEW fresh.streams_co_vw AS
-#'   SELECT s.*, h.accessible, h.spawning, h.rearing, h.lake_rearing
+#'   SELECT s.*, h.accessible, h.spawning, h.rearing, h.lake_rearing, h.wetland_rearing
 #'   FROM fresh.streams s
 #'   JOIN fresh.streams_habitat h ON s.id_segment = h.id_segment
 #'   WHERE h.species_code = 'CO'")
@@ -144,7 +144,8 @@ frs_habitat_classify <- function(conn, table, to,
        accessible boolean,
        spawning boolean,
        rearing boolean,
-       lake_rearing boolean
+       lake_rearing boolean,
+       wetland_rearing boolean
      )", to))
 
   # Delete existing rows for these WSGs — fast column filter, no subquery
@@ -340,9 +341,23 @@ frs_habitat_classify <- function(conn, table, to,
         .frs_sql_num(cw[1]), .frs_sql_num(cw[2]))
     }
 
+    # Wetland rearing — mirrors lake rearing, joined to fwa_wetlands_poly
+    # instead. Per-species opt-in via rules YAML / dimensions.csv lands on
+    # top of this column; this is the raw "segment is a wetland under the
+    # species' rear channel-width window" flag.
+    wetland_rear_cond <- "FALSE"
+    if (!is.null(params_sp$ranges$rear$channel_width)) {
+      cw <- params_sp$ranges$rear$channel_width
+      wetland_rear_cond <- sprintf(
+        "s.channel_width >= %s AND s.channel_width <= %s
+         AND s.waterbody_key IN (
+           SELECT waterbody_key FROM whse_basemapping.fwa_wetlands_poly)",
+        .frs_sql_num(cw[1]), .frs_sql_num(cw[2]))
+    }
+
     # INSERT joining pre-computed accessibility
     sql <- sprintf(
-      "INSERT INTO %s (id_segment, watershed_group_code, species_code, accessible, spawning, rearing, lake_rearing)
+      "INSERT INTO %s (id_segment, watershed_group_code, species_code, accessible, spawning, rearing, lake_rearing, wetland_rearing)
        SELECT
          s.id_segment,
          s.watershed_group_code,
@@ -350,11 +365,12 @@ frs_habitat_classify <- function(conn, table, to,
          a.accessible,
          CASE WHEN a.accessible AND (%s) THEN TRUE ELSE FALSE END,
          CASE WHEN a.accessible AND (%s) THEN TRUE ELSE FALSE END,
+         CASE WHEN a.accessible AND (%s) THEN TRUE ELSE FALSE END,
          CASE WHEN a.accessible AND (%s) THEN TRUE ELSE FALSE END
        FROM %s s
        INNER JOIN %s a ON s.id_segment = a.id_segment",
       to, .frs_quote_string(sp),
-      spawn_cond, rear_cond, lake_rear_cond,
+      spawn_cond, rear_cond, lake_rear_cond, wetland_rear_cond,
       table, acc_tbl_sp)
 
     .frs_db_execute(conn, sql)

--- a/man/frs_habitat_classify.Rd
+++ b/man/frs_habitat_classify.Rd
@@ -69,9 +69,9 @@ these species in the output table. Default \code{TRUE}.}
 \description{
 Fish-habitat convenience wrapper. Classifies segments in a segmented
 stream network for one or more species into a fixed output schema of
-\code{accessible / spawning / rearing / lake_rearing} booleans keyed by
-\code{species_code}. Produces long-format output: one row per segment x
-species.
+\code{accessible / spawning / rearing / lake_rearing / wetland_rearing}
+booleans keyed by \code{species_code}. Produces long-format output: one
+row per segment x species.
 }
 \details{
 For non-fish domains — thermal refugia, riparian connectivity,
@@ -114,7 +114,7 @@ DBI::dbGetQuery(conn, "
 # Join geometry back for mapping — id_segment links the two tables
 DBI::dbExecute(conn, "
   CREATE OR REPLACE VIEW fresh.streams_co_vw AS
-  SELECT s.*, h.accessible, h.spawning, h.rearing, h.lake_rearing
+  SELECT s.*, h.accessible, h.spawning, h.rearing, h.lake_rearing, h.wetland_rearing
   FROM fresh.streams s
   JOIN fresh.streams_habitat h ON s.id_segment = h.id_segment
   WHERE h.species_code = 'CO'")


### PR DESCRIPTION
## Summary

Adds a `wetland_rearing` boolean column to `frs_habitat_classify()`'s output schema, mirroring the existing `lake_rearing` pattern joined to `fwa_wetlands_poly` instead of `fwa_lakes_poly`. Prerequisite for link-side work that needs to distinguish wetland-based from lake-based rearing in compound rollups (see [link#51](https://github.com/NewGraphEnvironment/link/issues/51)).

## Changes

- `R/frs_habitat_classify.R`
  - Output schema gains `wetland_rearing boolean` alongside `lake_rearing`.
  - New `wetland_rear_cond` mirroring `lake_rear_cond` — same per-species rear channel-width window, joined to `whse_basemapping.fwa_wetlands_poly` on `waterbody_key`.
  - INSERT extended to populate the new column.
  - Docstring updated to list `wetland_rearing` in the output schema; example SELECT extended.
- `man/frs_habitat_classify.Rd` regenerated.

Per-species opt-in via rules YAML / dimensions.csv lands on top of this column in a follow-up — this PR is just the raw "segment is a wetland under the species' rear channel-width window" flag. Any species whose rear channel_width range matches today gets `wetland_rearing` evaluated the same way they get `lake_rearing` evaluated today.

## Test plan

- [x] `devtools::test(filter = "frs_habitat_classify")` on M1 — 41 PASS, 0 FAIL.
- [ ] Full `devtools::test()` on M4 (full-suite rerun scheduled separately; dispatched but slow on M1, not blocking).

No behaviour change for existing callers — `lake_rearing` semantics unchanged. `wetland_rearing` is a net-new column that defaults to `FALSE` for any species whose rear channel_width range doesn't include wetland-classified segments.

Bumps fresh to 0.16.0 (additive schema change).

Relates to [link#51](https://github.com/NewGraphEnvironment/link/issues/51).
