### PR TITLE
Honour rear waterbody_type in rules YAML for lake/wetland rearing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.16.0
+Version: 0.17.0
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fresh 0.17.0
+
+- `frs_habitat_classify()` now honours the `waterbody_type: L` / `waterbody_type: W` entries under a species' `rear:` rules in the rules YAML. Previously the `lake_rearing` / `wetland_rearing` booleans were set whenever a segment fell in the species' rear channel-width window and matched a lake/wetland `waterbody_key` — regardless of whether the species had a lake/wetland rear rule declared. Now the flag is `FALSE` unless the species has the matching rule, and the rule's optional `lake_ha_min` / `wetland_ha_min` threshold filters the polygon join to exclude waterbodies below that area ([#165](https://github.com/NewGraphEnvironment/fresh/issues/165)). Surfaced in link#51 when every species in link's bcfishpass and default bundles produced bit-identical `lake_rearing_ha` totals despite the bundles declaring different rear rules.
+
 # fresh 0.16.0
 
 - `frs_habitat_classify()` output schema gains a `wetland_rearing` boolean column, mirroring `lake_rearing` but joined to `whse_basemapping.fwa_wetlands_poly` on `waterbody_key` ([#164](https://github.com/NewGraphEnvironment/fresh/pull/164)). Additive schema change — existing callers are unaffected; `lake_rearing` semantics unchanged. Prerequisite for link's compound rearing rollup (link#51).

--- a/R/frs_habitat_classify.R
+++ b/R/frs_habitat_classify.R
@@ -330,29 +330,45 @@ frs_habitat_classify <- function(conn, table, to,
         sp_label_filter, sp, acc_tbl)
     }
 
-    # Lake rearing
+    # Lake / wetland rearing — gated per-species on the rules YAML.
+    # A species is classified as lake-rearing only if its `rear:` rules
+    # include a `waterbody_type: L` entry; optional `lake_ha_min` filters
+    # the lake area. Same pattern for wetlands via `waterbody_type: W`.
+    # Segments must still fall within the species' rear channel-width
+    # window. Without a matching rule, the boolean stays FALSE.
+    lake_rule    <- .frs_find_waterbody_rule(params_sp[["rules"]][["rear"]], "L")
+    wetland_rule <- .frs_find_waterbody_rule(params_sp[["rules"]][["rear"]], "W")
+
     lake_rear_cond <- "FALSE"
-    if (!is.null(params_sp$ranges$rear$channel_width)) {
+    if (!is.null(lake_rule) && !is.null(params_sp$ranges$rear$channel_width)) {
       cw <- params_sp$ranges$rear$channel_width
+      ha_min <- lake_rule[["lake_ha_min"]]
+      area_clause <- if (!is.null(ha_min) && !is.na(ha_min)) {
+        sprintf(" WHERE area_ha >= %s", .frs_sql_num(ha_min))
+      } else {
+        ""
+      }
       lake_rear_cond <- sprintf(
         "s.channel_width >= %s AND s.channel_width <= %s
          AND s.waterbody_key IN (
-           SELECT waterbody_key FROM whse_basemapping.fwa_lakes_poly)",
-        .frs_sql_num(cw[1]), .frs_sql_num(cw[2]))
+           SELECT waterbody_key FROM whse_basemapping.fwa_lakes_poly%s)",
+        .frs_sql_num(cw[1]), .frs_sql_num(cw[2]), area_clause)
     }
 
-    # Wetland rearing — mirrors lake rearing, joined to fwa_wetlands_poly
-    # instead. Per-species opt-in via rules YAML / dimensions.csv lands on
-    # top of this column; this is the raw "segment is a wetland under the
-    # species' rear channel-width window" flag.
     wetland_rear_cond <- "FALSE"
-    if (!is.null(params_sp$ranges$rear$channel_width)) {
+    if (!is.null(wetland_rule) && !is.null(params_sp$ranges$rear$channel_width)) {
       cw <- params_sp$ranges$rear$channel_width
+      ha_min <- wetland_rule[["wetland_ha_min"]]
+      area_clause <- if (!is.null(ha_min) && !is.na(ha_min)) {
+        sprintf(" WHERE area_ha >= %s", .frs_sql_num(ha_min))
+      } else {
+        ""
+      }
       wetland_rear_cond <- sprintf(
         "s.channel_width >= %s AND s.channel_width <= %s
          AND s.waterbody_key IN (
-           SELECT waterbody_key FROM whse_basemapping.fwa_wetlands_poly)",
-        .frs_sql_num(cw[1]), .frs_sql_num(cw[2]))
+           SELECT waterbody_key FROM whse_basemapping.fwa_wetlands_poly%s)",
+        .frs_sql_num(cw[1]), .frs_sql_num(cw[2]), area_clause)
     }
 
     # INSERT joining pre-computed accessibility

--- a/R/utils.R
+++ b/R/utils.R
@@ -301,6 +301,30 @@
 }
 
 
+#' Find a waterbody-type rule in a species' rear rules list
+#'
+#' Returns the first rear rule entry whose `waterbody_type` matches
+#' `wb_code` (typically `"L"` for lakes or `"W"` for wetlands), or
+#' `NULL` if the species has no such rule. Used by
+#' [frs_habitat_classify()] to gate `lake_rearing` / `wetland_rearing`
+#' flags on the rules-YAML declaration rather than classifying by
+#' channel-width alone.
+#'
+#' @param rules The `rear:` rules list from a species' entry in the
+#'   parsed rules YAML (e.g. `params_sp$rules$rear`).
+#' @param wb_code Character. One of `"L"` (lake), `"W"` (wetland).
+#' @return The matching rule (a named list) or `NULL` if none.
+#' @noRd
+.frs_find_waterbody_rule <- function(rules, wb_code) {
+  if (is.null(rules) || length(rules) == 0) return(NULL)
+  for (r in rules) {
+    wt <- r[["waterbody_type"]]
+    if (!is.null(wt) && identical(wt, wb_code)) return(r)
+  }
+  NULL
+}
+
+
 #' Add id_segment column to a working table
 #'
 #' Assigns a unique integer ID to every row. Uses `linear_feature_id`

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -73,3 +73,50 @@ test_that("frs_db_conn stops on missing env vars", {
   expect_error(frs_db_conn(dbname = "x", host = "x", port = ""), "PG_PORT_SHARE")
   expect_error(frs_db_conn(dbname = "x", host = "x", port = "5432", user = ""), "PG_USER_SHARE")
 })
+
+# -- .frs_find_waterbody_rule --------------------------------------------------
+
+test_that(".frs_find_waterbody_rule returns matching L rule", {
+  rules <- list(
+    list(edge_types = c("stream", "canal")),
+    list(waterbody_type = "R", channel_width = c(0, 9999)),
+    list(waterbody_type = "L", lake_ha_min = 100)
+  )
+  r <- .frs_find_waterbody_rule(rules, "L")
+  expect_type(r, "list")
+  expect_equal(r$waterbody_type, "L")
+  expect_equal(r$lake_ha_min, 100)
+})
+
+test_that(".frs_find_waterbody_rule returns matching W rule", {
+  rules <- list(
+    list(edge_types = "wetland", thresholds = FALSE),
+    list(waterbody_type = "W", wetland_ha_min = 5)
+  )
+  r <- .frs_find_waterbody_rule(rules, "W")
+  expect_equal(r$waterbody_type, "W")
+  expect_equal(r$wetland_ha_min, 5)
+})
+
+test_that(".frs_find_waterbody_rule returns NULL when no matching rule", {
+  rules <- list(
+    list(edge_types = c("stream", "canal")),
+    list(waterbody_type = "R", channel_width = c(0, 9999))
+  )
+  expect_null(.frs_find_waterbody_rule(rules, "L"))
+  expect_null(.frs_find_waterbody_rule(rules, "W"))
+})
+
+test_that(".frs_find_waterbody_rule handles NULL / empty rules", {
+  expect_null(.frs_find_waterbody_rule(NULL, "L"))
+  expect_null(.frs_find_waterbody_rule(list(), "L"))
+})
+
+test_that(".frs_find_waterbody_rule returns the first match if multiple", {
+  rules <- list(
+    list(waterbody_type = "L", lake_ha_min = 50),
+    list(waterbody_type = "L", lake_ha_min = 200)
+  )
+  r <- .frs_find_waterbody_rule(rules, "L")
+  expect_equal(r$lake_ha_min, 50)
+})


### PR DESCRIPTION
## Summary

- `frs_habitat_classify()` now honours the `waterbody_type: L` / `waterbody_type: W` entries under a species' `rear:` rules in the rules YAML.
- Previously `lake_rearing` / `wetland_rearing` booleans were set whenever a segment fell in the species' rear channel-width window AND its `waterbody_key` matched `fwa_lakes_poly` / `fwa_wetlands_poly`, regardless of whether the species had lake/wetland rules declared.
- Optional `lake_ha_min` / `wetland_ha_min` on the rule filters the polygon join to exclude waterbodies below that area.

## Surfacing

Found in [link#51](https://github.com/NewGraphEnvironment/link/issues/51) when every species in link's bcfishpass and default config bundles produced bit-identical `lake_rearing_ha` in the rollup — despite the bundles declaring different rear rules. ADMS SK example pre-fix: `bcfishpass` bundle (SK is lake-obligate) and `default` bundle (SK also lake-rearing) both reported identical 14114.65 ha — and BT under `bcfishpass` (`rear_lake = no`, no waterbody L rule) reported 14301.43 ha when it should have been 0.

## Test plan

- [x] 5 new unit tests for `.frs_find_waterbody_rule` helper (matches L, matches W, NULL rules, empty rules, returns first match)
- [x] `devtools::test(filter = "utils")` — 27 PASS, 0 FAIL
- [x] `devtools::test(filter = "frs_habitat_classify")` — 41 PASS, 0 FAIL
- [ ] Downstream integration: link#51 rollup comparison should now differ between bundles for BT/CH/CO/ST/WCT once link reinstalls fresh

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
