### PR TITLE
Accept wetland_ha_min predicate on rear waterbody_type: W rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.17.0
+Version: 0.17.1
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fresh 0.17.1
+
+- Params validator accepts `wetland_ha_min` predicate on rear rules with `waterbody_type: W` — mirrors the existing `lake_ha_min` / `waterbody_type: L` rule. The classifier in 0.17.0 already read `wetland_ha_min` from rear rules to filter the fwa_wetlands_poly join; the validator predicate allowlist hadn't been extended so rules YAML with the key was rejected. Surfaced in [link#51](https://github.com/NewGraphEnvironment/link/issues/51) when `lnk_rules_build()` started emitting `waterbody_type: W` rules with the threshold.
+
 # fresh 0.17.0
 
 - `frs_habitat_classify()` now honours the `waterbody_type: L` / `waterbody_type: W` entries under a species' `rear:` rules in the rules YAML. Previously the `lake_rearing` / `wetland_rearing` booleans were set whenever a segment fell in the species' rear channel-width window and matched a lake/wetland `waterbody_key` — regardless of whether the species had a lake/wetland rear rule declared. Now the flag is `FALSE` unless the species has the matching rule, and the rule's optional `lake_ha_min` / `wetland_ha_min` threshold filters the polygon join to exclude waterbodies below that area ([#165](https://github.com/NewGraphEnvironment/fresh/issues/165)). Surfaced in link#51 when every species in link's bcfishpass and default bundles produced bit-identical `lake_rearing_ha` totals despite the bundles declaring different rear rules.

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -133,8 +133,8 @@ frs_params <- function(conn = NULL,
   }
 
   valid_predicates <- c("edge_types", "edge_types_explicit",
-                        "waterbody_type", "lake_ha_min", "thresholds",
-                        "gradient", "channel_width",
+                        "waterbody_type", "lake_ha_min", "wetland_ha_min",
+                        "thresholds", "gradient", "channel_width",
                         "requires_connected", "connected_distance_max")
 
   for (sp in names(raw)) {
@@ -218,6 +218,22 @@ frs_params <- function(conn = NULL,
         length(rule[["lake_ha_min"]]) != 1) {
       stop(sprintf(
         "rules YAML %s/%s rule %d lake_ha_min must be a numeric scalar",
+        sp, habitat, idx), call. = FALSE)
+    }
+  }
+
+  if (!is.null(rule[["wetland_ha_min"]])) {
+    if (is.null(rule[["waterbody_type"]]) ||
+        rule[["waterbody_type"]] != "W") {
+      stop(sprintf(
+        paste0("rules YAML %s/%s rule %d uses wetland_ha_min without ",
+               "waterbody_type: W"),
+        sp, habitat, idx), call. = FALSE)
+    }
+    if (!is.numeric(rule[["wetland_ha_min"]]) ||
+        length(rule[["wetland_ha_min"]]) != 1) {
+      stop(sprintf(
+        "rules YAML %s/%s rule %d wetland_ha_min must be a numeric scalar",
         sp, habitat, idx), call. = FALSE)
     }
   }


### PR DESCRIPTION
Fixes #168. Mirrors lake_ha_min validation. Classifier in 0.17.0 already honoured wetland_ha_min but validator rejected it.