### PR TITLE
Long-format support for frs_habitat_overlay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.19.0
+Version: 0.20.0
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# fresh 0.20.0
+
+`frs_habitat_overlay()` accepts long-format known-habitat tables in addition to the original wide-format. Backward-compatible: the new `format` arg defaults to `"wide"`.
+
+- New args: `format = c("wide", "long")` and `long_value_col = "habitat_ind"`.
+- Long-format expects: join keys (per `by`) + `species_code` + `habitat_type` + a boolean / text indicator column. Each row is one (segment × species × habitat_type) tuple. Matches link's `user_habitat_classification.csv` shape, which is the bcfishpass `user_habitat_classification.csv` source format (before bcfishpass pivots it to wide for `streams_habitat_known`).
+- Indicator accepts boolean OR text — `'TRUE'` / `'t'` / `'true'` all qualify. Non-matching values (e.g. `'FALSE'`, NULL) skip.
+- Up-front validation: long-format known table must have all required columns (join keys + `species_code` + `habitat_type` + indicator). Errors clearly if missing.
+- Wide-format path unchanged. 11 new tests covering long-format unit + integration; previous wide tests all still pass (42 total on `frs_habitat_overlay`).
+
+Surfaced in [link#55](https://github.com/NewGraphEnvironment/link/issues/55) — link's `user_habitat_classification` table is loaded long-format by `lnk_pipeline_prepare`. Forcing a pivot in link to satisfy the wide-format assumption was special-case overhead. Now fresh handles either shape so callers use whichever they have.
+
 # fresh 0.19.0
 
 Decompose `frs_habitat_classify()` into composable pieces; rename `frs_habitat_known()` → `frs_habitat_overlay()`. Pre-1.0, breaking changes accepted to set the right shape before external use.

--- a/R/frs_habitat_overlay.R
+++ b/R/frs_habitat_overlay.R
@@ -12,11 +12,21 @@
 #' flag from `TRUE` to `FALSE`. Callers wanting "known beats model"
 #' semantics should preprocess the known table before calling.
 #'
-#' Expects the known-habitat table to be wide-format with one row per
-#' segment and a column per `{habitat_type}_{species_lower}` pair (e.g.
-#' `spawning_sk`, `rearing_co`). Boolean or NULL. Missing columns are
-#' skipped with a verbose message; they are not an error — many species
-#' have known data only for certain habitat types.
+#' Two known-table shapes supported via the `format` argument:
+#'
+#' - **`"wide"`** (default) — one row per segment, columns named
+#'   `{habitat_type}_{species_lower}` (e.g. `spawning_sk`, `rearing_co`).
+#'   Boolean or NULL. Matches the bcfishpass `streams_habitat_known`
+#'   convention. Missing per-species columns are skipped with a verbose
+#'   message — many species have known data only for certain habitat
+#'   types.
+#'
+#' - **`"long"`** — one row per (segment × species × habitat_type),
+#'   with a `species_code` column, a `habitat_type` column, and an
+#'   indicator column (`habitat_ind`) holding `'TRUE'`/`'FALSE'` (text)
+#'   or boolean. Matches link's `user_habitat_classification.csv`
+#'   shape. The function filters by species + habitat_type before the
+#'   join.
 #'
 #' Segments are matched between `table` and `known` using a join on the
 #' columns named in `by` (default `c("blue_line_key", "downstream_route_measure")`).
@@ -26,9 +36,10 @@
 #'   update in place. Must have columns `id_segment`, `species_code`,
 #'   plus boolean columns named in `habitat_types`, plus the join keys
 #'   in `by`.
-#' @param known Character. Schema-qualified wide-format known-habitat
-#'   table. Must have the join keys in `by`, plus per-species columns
-#'   named `{habitat_type}_{species_lower}`.
+#' @param known Character. Schema-qualified known-habitat table.
+#'   Wide-format: join keys + per-species columns. Long-format: join
+#'   keys + `species_code` + `habitat_type` + the indicator column
+#'   named in `long_value_col`.
 #' @param species Character vector. Species codes to ingest. `NULL`
 #'   (default) processes every species code present in `table`.
 #' @param habitat_types Character vector. Habitat-type columns to OR
@@ -37,6 +48,13 @@
 #'   columns present in `table`.
 #' @param by Character vector. Columns used to join `table` to `known`.
 #'   Default `c("blue_line_key", "downstream_route_measure")`.
+#' @param format Character. `"wide"` (default) or `"long"` — see
+#'   description.
+#' @param long_value_col Character. For `format = "long"`, the column
+#'   name in `known` that holds the indicator. Default `"habitat_ind"`.
+#'   Accepts: boolean values, OR text values `'TRUE'`/`'true'`/`'t'`
+#'   (case + whitespace insensitive). Anything else (NULL, `'FALSE'`,
+#'   `'1'`, `'yes'`, ...) skips the row.
 #' @param verbose Logical. Print per-species per-habitat summary.
 #'   Default `TRUE`.
 #'
@@ -62,7 +80,11 @@ frs_habitat_overlay <- function(conn, table, known,
                               habitat_types = c("spawning", "rearing",
                                                 "lake_rearing", "wetland_rearing"),
                               by = c("blue_line_key", "downstream_route_measure"),
+                              format = c("wide", "long"),
+                              long_value_col = "habitat_ind",
                               verbose = TRUE) {
+
+  format <- match.arg(format)
 
   # --- Argument validation ---
   stopifnot(
@@ -70,8 +92,10 @@ frs_habitat_overlay <- function(conn, table, known,
     is.character(table), length(table) == 1L, nchar(table) > 0,
     is.character(known), length(known) == 1L, nchar(known) > 0,
     is.character(habitat_types), length(habitat_types) > 0,
-    is.character(by), length(by) > 0
+    is.character(by), length(by) > 0,
+    is.character(long_value_col), length(long_value_col) == 1L
   )
+  .frs_validate_identifier(long_value_col, "long_value_col")
   if (!is.null(species)) {
     stopifnot(is.character(species), length(species) > 0)
   }
@@ -134,34 +158,66 @@ frs_habitat_overlay <- function(conn, table, known,
          call. = FALSE)
   }
 
-  # --- OR in flags per (habitat_type, species) where the column exists ---
+  # --- Long format: validate required columns up front ---
+  if (format == "long") {
+    required_long <- c(by, "species_code", "habitat_type", long_value_col)
+    missing_long <- setdiff(required_long, known_cols)
+    if (length(missing_long) > 0) {
+      stop(sprintf(
+        "long-format known table %s missing required columns: %s",
+        known, paste(missing_long, collapse = ", ")), call. = FALSE)
+    }
+  }
+
+  join_pred <- paste(sprintf("h.%s = k.%s", by, by), collapse = " AND ")
+
+  # --- OR in flags per (habitat_type, species) ---
   total_updates <- 0L
   for (sp in species) {
     sp_lower <- tolower(sp)
     for (hab in habitat_types) {
-      col <- paste0(hab, "_", sp_lower)
-      if (!col %in% known_cols) {
-        if (verbose) {
-          cat(sprintf("  skip %s/%s (no column `%s` in %s)\n",
-                      sp, hab, col, known))
+
+      sql <- if (format == "wide") {
+        col <- paste0(hab, "_", sp_lower)
+        if (!col %in% known_cols) {
+          if (verbose) {
+            cat(sprintf("  skip %s/%s (no column `%s` in %s)\n",
+                        sp, hab, col, known))
+          }
+          next
         }
-        next
+        sprintf(
+          "UPDATE %s AS h
+           SET %s = TRUE
+           FROM %s AS k
+           WHERE %s
+             AND h.species_code = %s
+             AND k.%s IS TRUE
+             AND (h.%s IS NULL OR h.%s = FALSE)",
+          table, hab, known, join_pred,
+          .frs_quote_string(sp),
+          col, hab, hab)
+      } else {
+        # long format: filter by species + habitat_type, accept boolean
+        # OR text 'TRUE' for the indicator column.
+        sprintf(
+          "UPDATE %s AS h
+           SET %s = TRUE
+           FROM %s AS k
+           WHERE %s
+             AND h.species_code = %s
+             AND k.species_code = %s
+             AND k.habitat_type = %s
+             AND (lower(trim(k.%s::text)) IN ('true', 't'))
+             AND (h.%s IS NULL OR h.%s = FALSE)",
+          table, hab, known, join_pred,
+          .frs_quote_string(sp),
+          .frs_quote_string(sp),
+          .frs_quote_string(hab),
+          long_value_col,
+          hab, hab)
       }
-      join_pred <- paste(sprintf("h.%s = k.%s", by, by), collapse = " AND ")
-      sql <- sprintf(
-        "UPDATE %s AS h
-         SET %s = TRUE
-         FROM %s AS k
-         WHERE %s
-           AND h.species_code = %s
-           AND k.%s IS TRUE
-           AND (h.%s IS NULL OR h.%s = FALSE)",
-        table, hab,
-        known,
-        join_pred,
-        .frs_quote_string(sp),
-        col,
-        hab, hab)
+
       n <- .frs_db_execute(conn, sql)
       total_updates <- total_updates + n
       if (verbose) {

--- a/man/frs_habitat_overlay.Rd
+++ b/man/frs_habitat_overlay.Rd
@@ -11,6 +11,8 @@ frs_habitat_overlay(
   species = NULL,
   habitat_types = c("spawning", "rearing", "lake_rearing", "wetland_rearing"),
   by = c("blue_line_key", "downstream_route_measure"),
+  format = c("wide", "long"),
+  long_value_col = "habitat_ind",
   verbose = TRUE
 )
 }
@@ -22,9 +24,10 @@ update in place. Must have columns \code{id_segment}, \code{species_code},
 plus boolean columns named in \code{habitat_types}, plus the join keys
 in \code{by}.}
 
-\item{known}{Character. Schema-qualified wide-format known-habitat
-table. Must have the join keys in \code{by}, plus per-species columns
-named \verb{\{habitat_type\}_\{species_lower\}}.}
+\item{known}{Character. Schema-qualified known-habitat table.
+Wide-format: join keys + per-species columns. Long-format: join
+keys + \code{species_code} + \code{habitat_type} + the indicator column
+named in \code{long_value_col}.}
 
 \item{species}{Character vector. Species codes to ingest. \code{NULL}
 (default) processes every species code present in \code{table}.}
@@ -35,6 +38,15 @@ columns present in \code{table}.}
 
 \item{by}{Character vector. Columns used to join \code{table} to \code{known}.
 Default \code{c("blue_line_key", "downstream_route_measure")}.}
+
+\item{format}{Character. \code{"wide"} (default) or \code{"long"} — see
+description.}
+
+\item{long_value_col}{Character. For \code{format = "long"}, the column
+name in \code{known} that holds the indicator. Default \code{"habitat_ind"}.
+Accepts: boolean values, OR text values \code{'TRUE'}/\code{'true'}/\code{'t'}
+(case + whitespace insensitive). Anything else (NULL, \code{'FALSE'},
+\code{'1'}, \code{'yes'}, ...) skips the row.}
 
 \item{verbose}{Logical. Print per-species per-habitat summary.
 Default \code{TRUE}.}
@@ -56,11 +68,21 @@ Known-habitat is \strong{purely additive}: this function never sets a
 flag from \code{TRUE} to \code{FALSE}. Callers wanting "known beats model"
 semantics should preprocess the known table before calling.
 
-Expects the known-habitat table to be wide-format with one row per
-segment and a column per \verb{\{habitat_type\}_\{species_lower\}} pair (e.g.
-\code{spawning_sk}, \code{rearing_co}). Boolean or NULL. Missing columns are
-skipped with a verbose message; they are not an error — many species
-have known data only for certain habitat types.
+Two known-table shapes supported via the \code{format} argument:
+\itemize{
+\item \strong{\code{"wide"}} (default) — one row per segment, columns named
+\verb{\{habitat_type\}_\{species_lower\}} (e.g. \code{spawning_sk}, \code{rearing_co}).
+Boolean or NULL. Matches the bcfishpass \code{streams_habitat_known}
+convention. Missing per-species columns are skipped with a verbose
+message — many species have known data only for certain habitat
+types.
+\item \strong{\code{"long"}} — one row per (segment × species × habitat_type),
+with a \code{species_code} column, a \code{habitat_type} column, and an
+indicator column (\code{habitat_ind}) holding \code{'TRUE'}/\code{'FALSE'} (text)
+or boolean. Matches link's \code{user_habitat_classification.csv}
+shape. The function filters by species + habitat_type before the
+join.
+}
 
 Segments are matched between \code{table} and \code{known} using a join on the
 columns named in \code{by} (default \code{c("blue_line_key", "downstream_route_measure")}).

--- a/tests/testthat/test-frs_habitat_overlay.R
+++ b/tests/testthat/test-frs_habitat_overlay.R
@@ -366,3 +366,153 @@ test_that("integration: idempotent on second call", {
     "SELECT spawning FROM working.test_known_h2")
   expect_true(result$spawning)
 })
+
+# -- Long format -----------------------------------------------------------
+
+test_that("long format: required columns checked up front", {
+  fake <- structure(list(), class = "DBIConnection")
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery",
+    mk_dbq("CO", TBL_DEFAULT,
+           c("blue_line_key", "downstream_route_measure")))  # missing species_code, habitat_type, habitat_ind
+  expect_error(
+    frs_habitat_overlay(fake, "ws.h", "ws.k",
+                        species = "CO", format = "long"),
+    "missing required columns")
+})
+
+test_that("long format: SQL filters by species_code + habitat_type", {
+  fake <- structure(list(), class = "DBIConnection")
+  captured <- list()
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery",
+    mk_dbq("CO", TBL_DEFAULT,
+           c("blue_line_key", "downstream_route_measure",
+             "species_code", "habitat_type", "habitat_ind")))
+  mockery::stub(frs_habitat_overlay, ".frs_db_execute", function(conn, sql) {
+    captured[[length(captured) + 1L]] <<- sql; 0L
+  })
+  invisible(frs_habitat_overlay(fake, "ws.h", "ws.k",
+    species = "CO", habitat_types = "spawning",
+    format = "long", verbose = FALSE))
+
+  expect_length(captured, 1)
+  sql <- captured[[1]]
+  expect_match(sql, "h\\.species_code = 'CO'")
+  expect_match(sql, "k\\.species_code = 'CO'")
+  expect_match(sql, "k\\.habitat_type = 'spawning'")
+  expect_match(sql, "lower\\(trim\\(k\\.habitat_ind::text\\)\\) IN \\('true', 't'\\)")
+  # Same additive guard
+  expect_match(sql, "AND \\(h\\.spawning IS NULL OR h\\.spawning = FALSE\\)")
+})
+
+test_that("long format: custom long_value_col interpolated", {
+  fake <- structure(list(), class = "DBIConnection")
+  captured <- character(0)
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery",
+    mk_dbq("CO", TBL_DEFAULT,
+           c("blue_line_key", "downstream_route_measure",
+             "species_code", "habitat_type", "is_known")))
+  mockery::stub(frs_habitat_overlay, ".frs_db_execute", function(conn, sql) {
+    captured <<- c(captured, sql); 0L
+  })
+  frs_habitat_overlay(fake, "ws.h", "ws.k",
+    species = "CO", habitat_types = "spawning",
+    format = "long", long_value_col = "is_known", verbose = FALSE)
+
+  expect_match(captured, "lower\\(trim\\(k\\.is_known::text\\)\\) IN \\(")
+  expect_no_match(captured, "habitat_ind")
+})
+
+test_that("long format: malicious long_value_col rejected by validator", {
+  fake <- structure(list(), class = "DBIConnection")
+  expect_error(
+    frs_habitat_overlay(fake, "ws.h", "ws.k",
+                        format = "long", long_value_col = "bad'; DROP --"))
+})
+
+# -- Integration: long format with text TRUE/FALSE indicator -----------------
+
+test_that("integration (long): text 'TRUE' indicator flips segment", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+  on.exit({
+    .frs_test_drop(conn, "working.test_known_long_h")
+    .frs_test_drop(conn, "working.test_known_long_k")
+    DBI::dbDisconnect(conn)
+  })
+
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_known_long_h (
+       id_segment integer, species_code text,
+       blue_line_key bigint, downstream_route_measure double precision,
+       spawning boolean, rearing boolean,
+       lake_rearing boolean, wetland_rearing boolean)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_known_long_h VALUES
+       (1, 'CO', 100, 10.0, FALSE, FALSE, FALSE, FALSE),
+       (2, 'CO', 100, 20.0, FALSE, FALSE, FALSE, FALSE)")
+
+  # Long-format known table: text indicator
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_known_long_k (
+       blue_line_key bigint, downstream_route_measure double precision,
+       species_code text, habitat_type text, habitat_ind text)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_known_long_k VALUES
+       (100, 10.0, 'CO', 'spawning', 'TRUE'),
+       (100, 20.0, 'CO', 'spawning', 'FALSE')")
+
+  invisible(frs_habitat_overlay(conn,
+    table = "working.test_known_long_h",
+    known = "working.test_known_long_k",
+    species = "CO", habitat_types = "spawning",
+    format = "long", verbose = FALSE))
+
+  result <- DBI::dbGetQuery(conn,
+    "SELECT id_segment, spawning FROM working.test_known_long_h ORDER BY id_segment")
+  # Segment 1 flips (habitat_ind = 'TRUE'); segment 2 stays (habitat_ind = 'FALSE')
+  expect_equal(result$spawning, c(TRUE, FALSE))
+})
+
+test_that("integration (long): boolean-typed indicator works", {
+  # Locks in the contract that long format accepts a boolean column,
+  # not just text. Postgres casts boolean to text as 'true'/'false'
+  # which the SQL filter normalises to lowercase before matching.
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+  on.exit({
+    .frs_test_drop(conn, "working.test_known_long_bool_h")
+    .frs_test_drop(conn, "working.test_known_long_bool_k")
+    DBI::dbDisconnect(conn)
+  })
+
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_known_long_bool_h (
+       id_segment integer, species_code text,
+       blue_line_key bigint, downstream_route_measure double precision,
+       spawning boolean, rearing boolean,
+       lake_rearing boolean, wetland_rearing boolean)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_known_long_bool_h VALUES
+       (1, 'CO', 100, 10.0, FALSE, FALSE, FALSE, FALSE),
+       (2, 'CO', 100, 20.0, FALSE, FALSE, FALSE, FALSE)")
+
+  # Long-format known table: BOOLEAN indicator (not text)
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_known_long_bool_k (
+       blue_line_key bigint, downstream_route_measure double precision,
+       species_code text, habitat_type text, habitat_ind boolean)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_known_long_bool_k VALUES
+       (100, 10.0, 'CO', 'spawning', TRUE),
+       (100, 20.0, 'CO', 'spawning', FALSE)")
+
+  invisible(frs_habitat_overlay(conn,
+    table = "working.test_known_long_bool_h",
+    known = "working.test_known_long_bool_k",
+    species = "CO", habitat_types = "spawning",
+    format = "long", verbose = FALSE))
+
+  result <- DBI::dbGetQuery(conn,
+    "SELECT id_segment, spawning FROM working.test_known_long_bool_h ORDER BY id_segment")
+  expect_equal(result$spawning, c(TRUE, FALSE))
+})


### PR DESCRIPTION
## Summary

`frs_habitat_overlay()` accepts long-format known-habitat tables in addition to the original wide-format. Backward-compatible: `format` defaults to `"wide"`.

### Long-format shape

```sql
(blue_line_key, downstream_route_measure, ..., species_code, habitat_type, habitat_ind)
-- one row per (segment × species × habitat_type) with indicator boolean/text
```

Matches link's `user_habitat_classification.csv` shape (which mirrors bcfishpass's source CSV format, before bcfishpass pivots it to wide for `streams_habitat_known`).

### Indicator value handling

`lower(trim(k.<col>::text)) IN ('true', 't')` — accepts:
- Boolean column (Postgres casts to text `'true'`/`'false'`)
- Text variants `'TRUE'`, `'true'`, `'True'`, `'t'`, `'T'`, with leading/trailing whitespace
- Anything else (NULL, `'FALSE'`, `'1'`, `'yes'`) skips

### API

```r
frs_habitat_overlay(conn, table, known,
  species = NULL,
  habitat_types = c("spawning", "rearing", "lake_rearing", "wetland_rearing"),
  by = c("blue_line_key", "downstream_route_measure"),
  format = c("wide", "long"),     # NEW
  long_value_col = "habitat_ind", # NEW
  verbose = TRUE)
```

### Test plan

- [x] **43 tests pass** on `frs_habitat_overlay` (was 31; gained 12 from long-format)
- [x] Full fresh suite **806 PASS / 0 FAIL / 12m06s** on m4
- [x] `/code-check` signed off — 2 findings fixed (normalise indicator value comparison; add boolean-typed integration test)
- [x] Backward compatibility: wide-format path unchanged, all prior tests still pass

### Surfaced reason

link's `user_habitat_classification` table is loaded long-format by `lnk_pipeline_prepare`. Forcing a pivot in link to satisfy wide-format was special-case overhead. Fresh now handles either shape so callers use whichever they have.

Closes #172. Companion to NewGraphEnvironment/link#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
