### PR TITLE
Rename overlay params + add bridge for 3-way joins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.20.0
+Version: 0.21.0
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# fresh 0.21.0
+
+`frs_habitat_overlay()` rename + 3-way bridge join. Pre-1.0 cleanup driven by review of v0.20.0; no deprecation alias.
+
+- **Param renames** (breaking):
+  - `table` → `to` (matches fresh's "destination" convention)
+  - `known` → `from` (matches "source" convention; also detaches from the "known habitat" provenance framing — function is the abstract overlay mechanism)
+- **New `bridge = NULL` parameter** for 3-way joins. When supplied, the SQL becomes `to ← bridge ← from` with range containment: `bridge.downstream_route_measure >= from.downstream_route_measure AND bridge.upstream_route_measure <= from.upstream_route_measure`. Lets `to` tables keyed by `id_segment` (e.g. `fresh.streams_habitat`) overlay from sources keyed by `(blue_line_key, drm)` ranges.
+- **Range columns auto-stripped from `by` in bridge mode** — `downstream_route_measure` / `upstream_route_measure` are handled by the range predicates, so they don't need to be (and shouldn't be) in the equality `by` clause.
+- `frs_habitat_classify()`'s `known = NULL` shortcut **dropped** (also breaking). Convenience hid configurability now that overlay has format + bridge knobs. Caller pattern is now explicitly two-step: `frs_habitat_classify()` then `frs_habitat_overlay()`.
+- Reads as a sentence: `frs_habitat_overlay(from = X, to = Y, bridge = Z)` — "overlay flags from X to Y via this bridge." Domain-agnostic — bridge isn't required to be `fresh.streams`; any segments table providing `id_segment` + range columns works (lake centerlines, wetland shorelines, future cottonwood-pinned segmentations).
+
+Surfaced in [link#55](https://github.com/NewGraphEnvironment/link/issues/55) when `fresh.streams_habitat` (keyed by `id_segment` only) needed overlay from `user_habitat_classification` (keyed by `(blue_line_key, drm)` with range `[drm, urm]`).
+
+Tests: 52 (was 43 in v0.20.0) — added bridge schema validation, SQL shape verification, range-containment integration test on a 3-segment fixture.
+
 # fresh 0.20.0
 
 `frs_habitat_overlay()` accepts long-format known-habitat tables in addition to the original wide-format. Backward-compatible: the new `format` arg defaults to `"wide"`.

--- a/R/frs_habitat_classify.R
+++ b/R/frs_habitat_classify.R
@@ -103,7 +103,6 @@ frs_habitat_classify <- function(conn, table, to,
                                  gate = TRUE,
                                  label_block = "blocked",
                                  barrier_overrides = NULL,
-                                 known = NULL,
                                  overwrite = TRUE,
                                  verbose = TRUE) {
   .frs_validate_identifier(table, "streams table")
@@ -112,9 +111,6 @@ frs_habitat_classify <- function(conn, table, to,
   stopifnot(is.logical(gate), length(gate) == 1)
   if (!is.null(barrier_overrides)) {
     .frs_validate_identifier(barrier_overrides, "barrier_overrides table")
-  }
-  if (!is.null(known)) {
-    .frs_validate_identifier(known, "known table")
   }
 
   breaks_tbl <- paste0(table, "_breaks")
@@ -317,15 +313,6 @@ frs_habitat_classify <- function(conn, table, to,
   }
 
   .frs_index_working(conn, to)
-
-  # Optional overlay: stitch known-habitat flags from a wide-format
-  # lookup table (e.g. user_habitat_classification) onto the rule-based
-  # classification. Purely additive — see frs_habitat_overlay().
-  if (!is.null(known)) {
-    if (verbose) cat("frs_habitat_classify: overlaying known habitat from ", known, "\n", sep = "")
-    frs_habitat_overlay(conn, table = to, known = known,
-                        species = species, verbose = verbose)
-  }
 
   invisible(conn)
 }

--- a/R/frs_habitat_overlay.R
+++ b/R/frs_habitat_overlay.R
@@ -1,109 +1,135 @@
-#' Overlay known-habitat flags onto a classified streams_habitat table
+#' Overlay flags from one table onto another
 #'
-#' After [frs_habitat_classify()] populates per-segment per-species
-#' habitat booleans from rules, `frs_habitat_overlay()` ORs in additional
-#' TRUE flags from a wide-format known-habitat table — capturing field
-#' observations / expert review / manual additions that the rule-based
-#' classifier doesn't reach. Mirrors the bcfishpass pipeline's blend of
-#' `habitat_linear_<sp>` (model) with `streams_habitat_known` (knowns)
-#' into the published `streams_habitat_linear`.
+#' OR-in boolean flags from a source table (`from`) onto an existing
+#' classified table (`to`), purely additively (`FALSE → TRUE` only,
+#' never reversed). Surfaced for the bcfishpass / link blend of
+#' rule-based classification (`frs_habitat_classify()`) with
+#' manually-curated knowns (`user_habitat_classification.csv`), but
+#' the mechanism is generic: any boolean-flagged source over any
+#' boolean-flagged target.
 #'
-#' Known-habitat is **purely additive**: this function never sets a
-#' flag from `TRUE` to `FALSE`. Callers wanting "known beats model"
-#' semantics should preprocess the known table before calling.
+#' Two source-table shapes (`format`):
 #'
-#' Two known-table shapes supported via the `format` argument:
-#'
-#' - **`"wide"`** (default) — one row per segment, columns named
-#'   `{habitat_type}_{species_lower}` (e.g. `spawning_sk`, `rearing_co`).
-#'   Boolean or NULL. Matches the bcfishpass `streams_habitat_known`
-#'   convention. Missing per-species columns are skipped with a verbose
-#'   message — many species have known data only for certain habitat
-#'   types.
-#'
+#' - **`"wide"`** — one row per segment, columns named
+#'   `{habitat_type}_{species_lower}` (e.g. `spawning_sk`). Boolean.
+#'   Matches the bcfishpass `streams_habitat_known` convention.
 #' - **`"long"`** — one row per (segment × species × habitat_type),
-#'   with a `species_code` column, a `habitat_type` column, and an
-#'   indicator column (`habitat_ind`) holding `'TRUE'`/`'FALSE'` (text)
-#'   or boolean. Matches link's `user_habitat_classification.csv`
-#'   shape. The function filters by species + habitat_type before the
-#'   join.
+#'   with `species_code`, `habitat_type`, and an indicator column
+#'   (`long_value_col`, default `habitat_ind`). Indicator can be
+#'   boolean or text (`'TRUE'`/`'true'`/`'t'` case + whitespace
+#'   insensitive). Matches link's `user_habitat_classification`
+#'   table.
 #'
-#' Segments are matched between `table` and `known` using a join on the
-#' columns named in `by` (default `c("blue_line_key", "downstream_route_measure")`).
+#' Two join modes (`bridge`):
+#'
+#' - **Direct (`bridge = NULL`)** — the `to` table has the join keys
+#'   directly. SQL does `to.<by> = from.<by>` (point match).
+#' - **Bridged (`bridge = "<segments_table>"`)** — the `to` table is
+#'   keyed by `id_segment` (e.g. `fresh.streams_habitat`) and lacks
+#'   the geographic keys in `by`. The bridge table provides the
+#'   link, with id_segment + range columns. SQL does a 3-way join:
+#'
+#'   ```
+#'   to.id_segment = bridge.id_segment
+#'   AND bridge.<by[1]> = from.<by[1]>
+#'   AND bridge.downstream_route_measure >= from.downstream_route_measure
+#'   AND bridge.upstream_route_measure   <= from.upstream_route_measure
+#'   ```
+#'
+#'   Range containment, not point match — covers the case where one
+#'   `from` row's `[drm, urm]` range maps to multiple bridge segments
+#'   (e.g. when other break sources fall inside the range).
+#'
+#' Future bridges aren't required to be `fresh.streams` — any table
+#' providing `id_segment` + the join-key columns + range columns
+#' works. Use cases include lake / wetland centerline segments or
+#' cottonwood-polygon segmentations pinned to a hydrology network.
 #'
 #' @param conn A [DBI::DBIConnection-class] object.
-#' @param table Character. Schema-qualified streams_habitat table to
-#'   update in place. Must have columns `id_segment`, `species_code`,
-#'   plus boolean columns named in `habitat_types`, plus the join keys
-#'   in `by`.
-#' @param known Character. Schema-qualified known-habitat table.
-#'   Wide-format: join keys + per-species columns. Long-format: join
-#'   keys + `species_code` + `habitat_type` + the indicator column
-#'   named in `long_value_col`.
+#' @param from Character. Schema-qualified source table providing
+#'   the flags to overlay. Wide- or long-format per `format`.
+#' @param to Character. Schema-qualified destination table to UPDATE
+#'   in place. Must have boolean columns named in `habitat_types`
+#'   plus a `species_code` column. Either has the join keys (`by`)
+#'   directly, or only `id_segment` (use `bridge` to resolve).
+#' @param bridge Character or `NULL`. Optional schema-qualified
+#'   segments table providing `id_segment` + the join keys in `by`
+#'   + `downstream_route_measure` + `upstream_route_measure`. When
+#'   provided, switches to a 3-way range-containment join. Default
+#'   `NULL` (direct point-match join — `to` must have the join keys).
+#'   **Note:** the range column names are currently hardcoded to FWA
+#'   convention (`downstream_route_measure` / `upstream_route_measure`).
+#'   `from` and `bridge` must both use these names; non-FWA segment
+#'   schemas would need a follow-up parameterisation.
 #' @param species Character vector. Species codes to ingest. `NULL`
-#'   (default) processes every species code present in `table`.
+#'   (default) processes every species code present in `to`.
 #' @param habitat_types Character vector. Habitat-type columns to OR
-#'   in. Defaults to the four standard ones: `c("spawning", "rearing",
-#'   "lake_rearing", "wetland_rearing")`. Must be a subset of the
-#'   columns present in `table`.
-#' @param by Character vector. Columns used to join `table` to `known`.
+#'   in. Defaults to the four standard ones: `c("spawning",
+#'   "rearing", "lake_rearing", "wetland_rearing")`. Must be a
+#'   subset of the columns present in `to`.
+#' @param by Character vector. Columns used to match `from` to either
+#'   `to` (when `bridge = NULL`) or to `bridge` (when bridge supplied).
 #'   Default `c("blue_line_key", "downstream_route_measure")`.
-#' @param format Character. `"wide"` (default) or `"long"` — see
-#'   description.
+#' @param format Character. `"wide"` (default) or `"long"`.
 #' @param long_value_col Character. For `format = "long"`, the column
-#'   name in `known` that holds the indicator. Default `"habitat_ind"`.
-#'   Accepts: boolean values, OR text values `'TRUE'`/`'true'`/`'t'`
-#'   (case + whitespace insensitive). Anything else (NULL, `'FALSE'`,
-#'   `'1'`, `'yes'`, ...) skips the row.
+#'   name in `from` that holds the indicator. Default
+#'   `"habitat_ind"`. Accepts boolean or `'true'`/`'t'` text
+#'   (case + whitespace insensitive).
 #' @param verbose Logical. Print per-species per-habitat summary.
 #'   Default `TRUE`.
 #'
 #' @return `conn` invisibly (for piping).
 #'
 #' @family habitat
-#'
 #' @export
 #'
 #' @examples
 #' \dontrun{
-#' conn <- frs_db_conn()
-#'
-#' # After frs_habitat_classify() populated working.streams_habitat,
-#' # OR in known habitat from a CSV-loaded table.
+#' # Direct join (target has the keys):
 #' frs_habitat_overlay(conn,
-#'   table   = "working.streams_habitat",
-#'   known   = "working.user_habitat_classification",
-#'   species = c("CO", "SK", "CH"))
+#'   from = "ws.user_habitat_classification",
+#'   to   = "ws.streams_habitat_keyed",
+#'   format = "long")
+#'
+#' # Bridged join (target is fresh.streams_habitat, keyed by id_segment):
+#' frs_habitat_overlay(conn,
+#'   from   = "ws.user_habitat_classification",
+#'   to     = "fresh.streams_habitat",
+#'   bridge = "fresh.streams",
+#'   format = "long")
 #' }
-frs_habitat_overlay <- function(conn, table, known,
-                              species = NULL,
-                              habitat_types = c("spawning", "rearing",
-                                                "lake_rearing", "wetland_rearing"),
-                              by = c("blue_line_key", "downstream_route_measure"),
-                              format = c("wide", "long"),
-                              long_value_col = "habitat_ind",
-                              verbose = TRUE) {
+frs_habitat_overlay <- function(conn, from, to,
+                                bridge = NULL,
+                                species = NULL,
+                                habitat_types = c("spawning", "rearing",
+                                                  "lake_rearing", "wetland_rearing"),
+                                by = c("blue_line_key", "downstream_route_measure"),
+                                format = c("wide", "long"),
+                                long_value_col = "habitat_ind",
+                                verbose = TRUE) {
 
   format <- match.arg(format)
 
   # --- Argument validation ---
   stopifnot(
     inherits(conn, "DBIConnection"),
-    is.character(table), length(table) == 1L, nchar(table) > 0,
-    is.character(known), length(known) == 1L, nchar(known) > 0,
+    is.character(from), length(from) == 1L, nchar(from) > 0,
+    is.character(to),   length(to)   == 1L, nchar(to)   > 0,
     is.character(habitat_types), length(habitat_types) > 0,
     is.character(by), length(by) > 0,
     is.character(long_value_col), length(long_value_col) == 1L
   )
-  .frs_validate_identifier(long_value_col, "long_value_col")
-  if (!is.null(species)) {
-    stopifnot(is.character(species), length(species) > 0)
+  if (!is.null(bridge)) {
+    stopifnot(is.character(bridge), length(bridge) == 1L, nchar(bridge) > 0)
+    .frs_validate_identifier(bridge, "bridge")
   }
-  .frs_validate_identifier(table, "table")
-  .frs_validate_identifier(known, "known")
+  .frs_validate_identifier(from, "from")
+  .frs_validate_identifier(to,   "to")
+  .frs_validate_identifier(long_value_col, "long_value_col")
   for (b in by) .frs_validate_identifier(b, "by column")
   for (h in habitat_types) .frs_validate_identifier(h, "habitat_types entry")
   if (!is.null(species)) {
+    stopifnot(is.character(species), length(species) > 0)
     bad <- !grepl("^[A-Za-z]+$", species)
     if (any(bad)) {
       stop(sprintf("species code(s) must be alphabetic only: %s",
@@ -111,65 +137,109 @@ frs_habitat_overlay <- function(conn, table, known,
     }
   }
 
-  # Validate habitat_types are columns in `table` so we don't UPDATE
-  # mid-loop and crash on a missing column halfway through (partial
-  # update, no rollback).
-  table_parts <- strsplit(table, "\\.", fixed = FALSE)[[1]]
-  if (length(table_parts) != 2L) {
-    stop("`table` must be schema-qualified (e.g. 'working.streams_habitat')",
+  # Validate habitat_types are columns in `to` so we don't UPDATE
+  # mid-loop and crash on a missing column halfway through.
+  to_parts <- strsplit(to, "\\.", fixed = FALSE)[[1]]
+  if (length(to_parts) != 2L) {
+    stop("`to` must be schema-qualified (e.g. 'working.streams_habitat')",
          call. = FALSE)
   }
-  table_cols <- DBI::dbGetQuery(conn, sprintf(
+  to_cols <- DBI::dbGetQuery(conn, sprintf(
     "SELECT column_name FROM information_schema.columns
      WHERE table_schema = %s AND table_name = %s",
-    .frs_quote_string(table_parts[1]),
-    .frs_quote_string(table_parts[2])))$column_name
-  missing_hab <- setdiff(habitat_types, table_cols)
+    .frs_quote_string(to_parts[1]),
+    .frs_quote_string(to_parts[2])))$column_name
+  missing_hab <- setdiff(habitat_types, to_cols)
   if (length(missing_hab) > 0) {
     stop(sprintf(
       "habitat_types not found as columns in %s: %s",
-      table, paste(missing_hab, collapse = ", ")), call. = FALSE)
+      to, paste(missing_hab, collapse = ", ")), call. = FALSE)
   }
 
   # --- Discover species set ---
   if (is.null(species)) {
     species <- DBI::dbGetQuery(conn, sprintf(
       "SELECT DISTINCT species_code FROM %s ORDER BY species_code",
-      table))$species_code
+      to))$species_code
     if (length(species) == 0) {
-      if (verbose) cat("frs_habitat_overlay: table is empty, nothing to do.\n")
+      if (verbose) cat("frs_habitat_overlay: target table is empty, nothing to do.\n")
       return(invisible(conn))
     }
   }
 
-  # --- Discover known-table columns once (to skip missing per-species cols) ---
-  known_parts <- strsplit(known, "\\.", fixed = FALSE)[[1]]
-  if (length(known_parts) != 2L) {
-    stop("`known` must be schema-qualified (e.g. 'working.user_habitat_classification')",
+  # --- Discover from-table columns ---
+  from_parts <- strsplit(from, "\\.", fixed = FALSE)[[1]]
+  if (length(from_parts) != 2L) {
+    stop("`from` must be schema-qualified (e.g. 'working.user_habitat_classification')",
          call. = FALSE)
   }
-  known_cols <- DBI::dbGetQuery(conn, sprintf(
+  from_cols <- DBI::dbGetQuery(conn, sprintf(
     "SELECT column_name FROM information_schema.columns
      WHERE table_schema = %s AND table_name = %s",
-    .frs_quote_string(known_parts[1]),
-    .frs_quote_string(known_parts[2])))$column_name
-  if (length(known_cols) == 0) {
-    stop(sprintf("known table %s not found or has no columns", known),
+    .frs_quote_string(from_parts[1]),
+    .frs_quote_string(from_parts[2])))$column_name
+  if (length(from_cols) == 0) {
+    stop(sprintf("from table %s not found or has no columns", from),
          call. = FALSE)
   }
 
-  # --- Long format: validate required columns up front ---
+  # --- Long-format: validate required columns up front ---
   if (format == "long") {
     required_long <- c(by, "species_code", "habitat_type", long_value_col)
-    missing_long <- setdiff(required_long, known_cols)
+    missing_long <- setdiff(required_long, from_cols)
     if (length(missing_long) > 0) {
       stop(sprintf(
-        "long-format known table %s missing required columns: %s",
-        known, paste(missing_long, collapse = ", ")), call. = FALSE)
+        "long-format `from` table %s missing required columns: %s",
+        from, paste(missing_long, collapse = ", ")), call. = FALSE)
     }
   }
 
-  join_pred <- paste(sprintf("h.%s = k.%s", by, by), collapse = " AND ")
+  # --- Bridge validation: must have id_segment + by + range columns ---
+  if (!is.null(bridge)) {
+    bridge_parts <- strsplit(bridge, "\\.", fixed = FALSE)[[1]]
+    if (length(bridge_parts) != 2L) {
+      stop("`bridge` must be schema-qualified (e.g. 'fresh.streams')",
+           call. = FALSE)
+    }
+    bridge_cols <- DBI::dbGetQuery(conn, sprintf(
+      "SELECT column_name FROM information_schema.columns
+       WHERE table_schema = %s AND table_name = %s",
+      .frs_quote_string(bridge_parts[1]),
+      .frs_quote_string(bridge_parts[2])))$column_name
+    required_bridge <- c("id_segment", by,
+                          "downstream_route_measure", "upstream_route_measure")
+    missing_bridge <- setdiff(required_bridge, bridge_cols)
+    if (length(missing_bridge) > 0) {
+      stop(sprintf(
+        "bridge table %s missing required columns: %s",
+        bridge, paste(missing_bridge, collapse = ", ")), call. = FALSE)
+    }
+  }
+
+  # --- Build join clause once ---
+  if (is.null(bridge)) {
+    # Direct: to ↔ from on by columns
+    from_clause <- sprintf("FROM %s AS k", from)
+    join_pred   <- paste(sprintf("h.%s = k.%s", by, by), collapse = " AND ")
+  } else {
+    # 3-way: to.id_segment = bridge.id_segment + bridge ranges contain from.
+    # Range columns are handled by the >= / <= predicates below; strip
+    # them from the equality `by` clause so we don't double-constrain
+    # (point match on drm would always fail when the from range is
+    # wider than the bridge segment).
+    range_cols <- c("downstream_route_measure", "upstream_route_measure")
+    by_eq <- setdiff(by, range_cols)
+    if (length(by_eq) == 0) {
+      stop("`by` must include at least one non-range column when `bridge` is set",
+           call. = FALSE)
+    }
+    from_clause <- sprintf("FROM %s AS s, %s AS k", bridge, from)
+    bk_pred <- paste(sprintf("s.%s = k.%s", by_eq, by_eq), collapse = " AND ")
+    join_pred <- paste0(
+      "h.id_segment = s.id_segment AND ", bk_pred,
+      " AND s.downstream_route_measure >= k.downstream_route_measure",
+      " AND s.upstream_route_measure   <= k.upstream_route_measure")
+  }
 
   # --- OR in flags per (habitat_type, species) ---
   total_updates <- 0L
@@ -179,38 +249,37 @@ frs_habitat_overlay <- function(conn, table, known,
 
       sql <- if (format == "wide") {
         col <- paste0(hab, "_", sp_lower)
-        if (!col %in% known_cols) {
+        if (!col %in% from_cols) {
           if (verbose) {
             cat(sprintf("  skip %s/%s (no column `%s` in %s)\n",
-                        sp, hab, col, known))
+                        sp, hab, col, from))
           }
           next
         }
         sprintf(
           "UPDATE %s AS h
            SET %s = TRUE
-           FROM %s AS k
+           %s
            WHERE %s
              AND h.species_code = %s
              AND k.%s IS TRUE
              AND (h.%s IS NULL OR h.%s = FALSE)",
-          table, hab, known, join_pred,
+          to, hab, from_clause, join_pred,
           .frs_quote_string(sp),
           col, hab, hab)
       } else {
-        # long format: filter by species + habitat_type, accept boolean
-        # OR text 'TRUE' for the indicator column.
+        # long format
         sprintf(
           "UPDATE %s AS h
            SET %s = TRUE
-           FROM %s AS k
+           %s
            WHERE %s
              AND h.species_code = %s
              AND k.species_code = %s
              AND k.habitat_type = %s
              AND (lower(trim(k.%s::text)) IN ('true', 't'))
              AND (h.%s IS NULL OR h.%s = FALSE)",
-          table, hab, known, join_pred,
+          to, hab, from_clause, join_pred,
           .frs_quote_string(sp),
           .frs_quote_string(sp),
           .frs_quote_string(hab),

--- a/man/frs_habitat_classify.Rd
+++ b/man/frs_habitat_classify.Rd
@@ -14,7 +14,6 @@ frs_habitat_classify(
   gate = TRUE,
   label_block = "blocked",
   barrier_overrides = NULL,
-  known = NULL,
   overwrite = TRUE,
   verbose = TRUE
 )

--- a/man/frs_habitat_overlay.Rd
+++ b/man/frs_habitat_overlay.Rd
@@ -2,12 +2,13 @@
 % Please edit documentation in R/frs_habitat_overlay.R
 \name{frs_habitat_overlay}
 \alias{frs_habitat_overlay}
-\title{Overlay known-habitat flags onto a classified streams_habitat table}
+\title{Overlay flags from one table onto another}
 \usage{
 frs_habitat_overlay(
   conn,
-  table,
-  known,
+  from,
+  to,
+  bridge = NULL,
   species = NULL,
   habitat_types = c("spawning", "rearing", "lake_rearing", "wetland_rearing"),
   by = c("blue_line_key", "downstream_route_measure"),
@@ -19,34 +20,43 @@ frs_habitat_overlay(
 \arguments{
 \item{conn}{A \link[DBI:DBIConnection-class]{DBI::DBIConnection} object.}
 
-\item{table}{Character. Schema-qualified streams_habitat table to
-update in place. Must have columns \code{id_segment}, \code{species_code},
-plus boolean columns named in \code{habitat_types}, plus the join keys
-in \code{by}.}
+\item{from}{Character. Schema-qualified source table providing
+the flags to overlay. Wide- or long-format per \code{format}.}
 
-\item{known}{Character. Schema-qualified known-habitat table.
-Wide-format: join keys + per-species columns. Long-format: join
-keys + \code{species_code} + \code{habitat_type} + the indicator column
-named in \code{long_value_col}.}
+\item{to}{Character. Schema-qualified destination table to UPDATE
+in place. Must have boolean columns named in \code{habitat_types}
+plus a \code{species_code} column. Either has the join keys (\code{by})
+directly, or only \code{id_segment} (use \code{bridge} to resolve).}
+
+\item{bridge}{Character or \code{NULL}. Optional schema-qualified
+segments table providing \code{id_segment} + the join keys in \code{by}
+\itemize{
+\item \code{downstream_route_measure} + \code{upstream_route_measure}. When
+provided, switches to a 3-way range-containment join. Default
+\code{NULL} (direct point-match join — \code{to} must have the join keys).
+\strong{Note:} the range column names are currently hardcoded to FWA
+convention (\code{downstream_route_measure} / \code{upstream_route_measure}).
+\code{from} and \code{bridge} must both use these names; non-FWA segment
+schemas would need a follow-up parameterisation.
+}}
 
 \item{species}{Character vector. Species codes to ingest. \code{NULL}
-(default) processes every species code present in \code{table}.}
+(default) processes every species code present in \code{to}.}
 
 \item{habitat_types}{Character vector. Habitat-type columns to OR
-in. Defaults to the four standard ones: \code{c("spawning", "rearing", "lake_rearing", "wetland_rearing")}. Must be a subset of the
-columns present in \code{table}.}
+in. Defaults to the four standard ones: \code{c("spawning", "rearing", "lake_rearing", "wetland_rearing")}. Must be a
+subset of the columns present in \code{to}.}
 
-\item{by}{Character vector. Columns used to join \code{table} to \code{known}.
+\item{by}{Character vector. Columns used to match \code{from} to either
+\code{to} (when \code{bridge = NULL}) or to \code{bridge} (when bridge supplied).
 Default \code{c("blue_line_key", "downstream_route_measure")}.}
 
-\item{format}{Character. \code{"wide"} (default) or \code{"long"} — see
-description.}
+\item{format}{Character. \code{"wide"} (default) or \code{"long"}.}
 
 \item{long_value_col}{Character. For \code{format = "long"}, the column
-name in \code{known} that holds the indicator. Default \code{"habitat_ind"}.
-Accepts: boolean values, OR text values \code{'TRUE'}/\code{'true'}/\code{'t'}
-(case + whitespace insensitive). Anything else (NULL, \code{'FALSE'},
-\code{'1'}, \code{'yes'}, ...) skips the row.}
+name in \code{from} that holds the indicator. Default
+\code{"habitat_ind"}. Accepts boolean or \code{'true'}/\code{'t'} text
+(case + whitespace insensitive).}
 
 \item{verbose}{Logical. Print per-species per-habitat summary.
 Default \code{TRUE}.}
@@ -55,48 +65,67 @@ Default \code{TRUE}.}
 \code{conn} invisibly (for piping).
 }
 \description{
-After \code{\link[=frs_habitat_classify]{frs_habitat_classify()}} populates per-segment per-species
-habitat booleans from rules, \code{frs_habitat_overlay()} ORs in additional
-TRUE flags from a wide-format known-habitat table — capturing field
-observations / expert review / manual additions that the rule-based
-classifier doesn't reach. Mirrors the bcfishpass pipeline's blend of
-\verb{habitat_linear_<sp>} (model) with \code{streams_habitat_known} (knowns)
-into the published \code{streams_habitat_linear}.
+OR-in boolean flags from a source table (\code{from}) onto an existing
+classified table (\code{to}), purely additively (\verb{FALSE → TRUE} only,
+never reversed). Surfaced for the bcfishpass / link blend of
+rule-based classification (\code{frs_habitat_classify()}) with
+manually-curated knowns (\code{user_habitat_classification.csv}), but
+the mechanism is generic: any boolean-flagged source over any
+boolean-flagged target.
 }
 \details{
-Known-habitat is \strong{purely additive}: this function never sets a
-flag from \code{TRUE} to \code{FALSE}. Callers wanting "known beats model"
-semantics should preprocess the known table before calling.
-
-Two known-table shapes supported via the \code{format} argument:
+Two source-table shapes (\code{format}):
 \itemize{
-\item \strong{\code{"wide"}} (default) — one row per segment, columns named
-\verb{\{habitat_type\}_\{species_lower\}} (e.g. \code{spawning_sk}, \code{rearing_co}).
-Boolean or NULL. Matches the bcfishpass \code{streams_habitat_known}
-convention. Missing per-species columns are skipped with a verbose
-message — many species have known data only for certain habitat
-types.
+\item \strong{\code{"wide"}} — one row per segment, columns named
+\verb{\{habitat_type\}_\{species_lower\}} (e.g. \code{spawning_sk}). Boolean.
+Matches the bcfishpass \code{streams_habitat_known} convention.
 \item \strong{\code{"long"}} — one row per (segment × species × habitat_type),
-with a \code{species_code} column, a \code{habitat_type} column, and an
-indicator column (\code{habitat_ind}) holding \code{'TRUE'}/\code{'FALSE'} (text)
-or boolean. Matches link's \code{user_habitat_classification.csv}
-shape. The function filters by species + habitat_type before the
-join.
+with \code{species_code}, \code{habitat_type}, and an indicator column
+(\code{long_value_col}, default \code{habitat_ind}). Indicator can be
+boolean or text (\code{'TRUE'}/\code{'true'}/\code{'t'} case + whitespace
+insensitive). Matches link's \code{user_habitat_classification}
+table.
 }
 
-Segments are matched between \code{table} and \code{known} using a join on the
-columns named in \code{by} (default \code{c("blue_line_key", "downstream_route_measure")}).
+Two join modes (\code{bridge}):
+\itemize{
+\item \strong{Direct (\code{bridge = NULL})} — the \code{to} table has the join keys
+directly. SQL does \verb{to.<by> = from.<by>} (point match).
+\item \strong{Bridged (\code{bridge = "<segments_table>"})} — the \code{to} table is
+keyed by \code{id_segment} (e.g. \code{fresh.streams_habitat}) and lacks
+the geographic keys in \code{by}. The bridge table provides the
+link, with id_segment + range columns. SQL does a 3-way join:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{to.id_segment = bridge.id_segment
+AND bridge.<by[1]> = from.<by[1]>
+AND bridge.downstream_route_measure >= from.downstream_route_measure
+AND bridge.upstream_route_measure   <= from.upstream_route_measure
+}\if{html}{\out{</div>}}
+
+Range containment, not point match — covers the case where one
+\code{from} row's \verb{[drm, urm]} range maps to multiple bridge segments
+(e.g. when other break sources fall inside the range).
+}
+
+Future bridges aren't required to be \code{fresh.streams} — any table
+providing \code{id_segment} + the join-key columns + range columns
+works. Use cases include lake / wetland centerline segments or
+cottonwood-polygon segmentations pinned to a hydrology network.
 }
 \examples{
 \dontrun{
-conn <- frs_db_conn()
-
-# After frs_habitat_classify() populated working.streams_habitat,
-# OR in known habitat from a CSV-loaded table.
+# Direct join (target has the keys):
 frs_habitat_overlay(conn,
-  table   = "working.streams_habitat",
-  known   = "working.user_habitat_classification",
-  species = c("CO", "SK", "CH"))
+  from = "ws.user_habitat_classification",
+  to   = "ws.streams_habitat_keyed",
+  format = "long")
+
+# Bridged join (target is fresh.streams_habitat, keyed by id_segment):
+frs_habitat_overlay(conn,
+  from   = "ws.user_habitat_classification",
+  to     = "fresh.streams_habitat",
+  bridge = "fresh.streams",
+  format = "long")
 }
 }
 \seealso{

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,33 @@
+# Findings — #174 overlay rename + bridge
+
+## Naming convention surveyed (2026-04-26)
+
+| pattern | examples |
+|---|---|
+| `to` for write destination | `frs_habitat_classify(to)`, `frs_break_apply(to)`, `frs_aggregate(to)` |
+| `from` for read source | `frs_barriers_minimal(from)` |
+| Bare descriptive nouns | `points`, `features`, `breaks`, `barrier_overrides` |
+| No `_tbl` suffix on params | (only in internal vars) |
+
+**Decision:** `from`/`to` for source/destination (matches existing fresh convention). `bridge` for the 3-way join intermediary (more explicit than `via`).
+
+## Naming dissonance fixed
+
+- Old: `table = streams_habitat`, `known = user_habitat_classification`
+  - "known" presupposes provenance; function name was already `overlay` (mechanism), so param naming was inconsistent with function naming.
+  - "table" was generic; could read as "the table being acted upon" but didn't clarify direction.
+- New: `to = streams_habitat`, `from = user_habitat_classification`, `bridge = streams`
+  - Reads as a sentence: "overlay flags from X to Y via this bridge"
+  - Domain-agnostic: the bridge can be any segmented network, not just streams. Future: cottonwood polygons pinned to network, lake centerlines, wetland shorelines, anything that maps id_segment ↔ join keys.
+
+## Bridge mechanism
+
+**Without bridge** (NULL): direct point-match join `to.<by> = from.<by>` (equality on the join key columns). Works when target table has the geographic keys directly.
+
+**With bridge**: 3-way join. Bridge provides id_segment + range columns:
+- `to.id_segment = bridge.id_segment` (FK link)
+- `bridge.<by[1]> = from.<by[1]>` (e.g. blue_line_key)
+- `bridge.downstream_route_measure >= from.downstream_route_measure`
+- `bridge.upstream_route_measure <= from.upstream_route_measure`
+
+Range containment matters because user_habitat_classification rows define `[drm, urm]` ranges, and the lnk_pipeline_break habitat_endpoints step ensures fresh.streams has segments WITHIN those ranges (one or more per user_habitat row). The overlay needs to flag ALL fresh segments contained in the user_habitat range.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress
+
+## Session 2026-04-26 — #174
+
+- Branched off main (post v0.20.0 tag).
+- PWF baseline.
+- Naming finalised through user pushback: `from`/`to`/`bridge` (was `known`/`table`/`streams|segments|via`). Domain-agnostic, readable as sentence.
+
+Next: rename + bridge implementation.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,49 @@
+# Task: rename overlay params + add bridge support (#174)
+
+Pre-1.0 cleanup driven by review of v0.20.0:
+- Rename `table` → `to` (matches fresh's "destination" convention)
+- Rename `known` → `from` (matches fresh's "source" convention; also detaches from "known habitat" provenance framing — function is the abstract "overlay" mechanism)
+- Add `bridge = NULL` — when supplied, do 3-way join with range containment so target tables keyed by `id_segment` (e.g. `fresh.streams_habitat`) can be overlaid from sources keyed by `(blue_line_key, drm)` or any other geographic key.
+
+After this lands, function reads as a sentence: **"overlay flags `from` X `to` Y `bridge` Z"** for any kind of segmented network — streams today, lakes/wetlands/cottonwood-pinned-to-segments tomorrow.
+
+## Phases
+
+- [ ] Phase 1 — PWF baseline
+- [ ] Phase 2 — Param rename: `table` → `to`, `known` → `from`. Update R, tests, docs, NEWS. No deprecation alias (pre-1.0).
+- [ ] Phase 3 — Add `bridge = NULL` parameter. When NULL, behave as today (direct point-match join). When non-NULL, do 3-way join with range containment.
+- [ ] Phase 4 — Update SQL builders (both wide + long format) to support bridge mode.
+- [ ] Phase 5 — Tests for bridge: range containment, NULL = unchanged behavior, missing range columns error, integration test with real fixture.
+- [ ] Phase 6 — `/code-check` on diff
+- [ ] Phase 7 — Full suite via rtj harness
+- [ ] Phase 8 — NEWS + version bump → 0.21.0
+- [ ] Phase 9 — PR, fix #174
+
+## Bridge SQL shape
+
+```sql
+UPDATE <to> AS h
+SET <hab> = TRUE
+FROM <bridge> AS s, <from> AS k
+WHERE h.id_segment = s.id_segment
+  AND s.<by[1]> = k.<by[1]>            -- e.g. blue_line_key
+  AND s.downstream_route_measure >= k.downstream_route_measure
+  AND s.upstream_route_measure   <= k.upstream_route_measure
+  AND <species/habitat filters>
+  AND <additive guard>
+```
+
+Range-containment is the key: the bridge segment's [drm, urm] must lie within the source's [drm, urm].
+
+## Acceptance
+
+- All existing wide-format tests still pass with renamed params
+- Long-format tests still pass
+- New bridge tests cover: 3-way join range containment, integration with realistic fixture, error when bridge keys mismatch
+- Full suite green
+- `/code-check` signed off
+
+## Risks
+
+- **Breaking change** on `table` and `known` arg names. Pre-1.0, no deprecation alias. Link side already on a parked branch (`55-call-frs-habitat-overlay`) — will need to update arg names there too.
+- **Range containment vs point match** is semantically distinct. `via = NULL` keeps point-match semantics; `via = "..."` opts into range. Document clearly.

--- a/tests/testthat/test-frs_habitat_overlay.R
+++ b/tests/testthat/test-frs_habitat_overlay.R
@@ -6,8 +6,8 @@
 
 # Helper: build a dbGetQuery mock that returns
 # - species list for `SELECT DISTINCT species_code`
-# - target table columns when the info_schema query targets `table_name = 'h'`
-# - known table columns when targeting `table_name = 'k'`
+# - destination (`to`) table columns when info_schema targets `table_name = 'h'`
+# - source (`from`) table columns when targeting `table_name = 'k'`
 mk_dbq <- function(species, table_cols, known_cols) {
   function(conn, sql) {
     if (grepl("DISTINCT species_code", sql)) {
@@ -33,15 +33,23 @@ TBL_DEFAULT <- c("id_segment", "species_code",
 
 test_that("frs_habitat_overlay validates conn", {
   expect_error(
-    frs_habitat_overlay("not a conn", "x.y", "x.z"),
+    frs_habitat_overlay("not a conn", from = "x.z", to = "x.y"),
     "DBIConnection")
 })
 
-test_that("frs_habitat_overlay validates table / known are schema-qualified strings", {
+test_that("frs_habitat_overlay validates from / to are schema-qualified strings", {
   fake <- structure(list(), class = "DBIConnection")
-  expect_error(frs_habitat_overlay(fake, "", "x.y"))
-  expect_error(frs_habitat_overlay(fake, "x.y", ""))
+  expect_error(frs_habitat_overlay(fake, from = "x.y", to = ""))
+  expect_error(frs_habitat_overlay(fake, from = "", to = "x.y"))
   expect_error(frs_habitat_overlay(fake, c("a", "b"), "x.y"))
+})
+
+test_that("frs_habitat_overlay rejects malicious from / to identifiers", {
+  fake <- structure(list(), class = "DBIConnection")
+  expect_error(
+    frs_habitat_overlay(fake, from = "ws.k; DROP TABLE x; --", to = "ws.h"))
+  expect_error(
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h; DROP TABLE x; --"))
 })
 
 test_that("frs_habitat_overlay requires schema-qualified known table", {
@@ -51,7 +59,7 @@ test_that("frs_habitat_overlay requires schema-qualified known table", {
   mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery",
     mk_dbq("CO", TBL_DEFAULT, character(0)))
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "no_schema",
+    frs_habitat_overlay(fake, from = "no_schema", to = "ws.h",
                       species = "CO"),
     "schema-qualified")
 })
@@ -74,7 +82,7 @@ test_that("empty table -> early return without error", {
   })
 
   expect_silent(suppressMessages(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", verbose = FALSE)
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", verbose = FALSE)
   ))
 })
 
@@ -97,7 +105,7 @@ test_that("missing per-species column is skipped, not an error", {
   })
 
   out <- expect_output(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", species = "CT", verbose = TRUE),
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", species = "CT", verbose = TRUE),
     "skip CT/spawning")
 
   # No UPDATEs should have run for CT (no matching columns)
@@ -118,7 +126,7 @@ test_that("UPDATE SQL ORs in TRUE on matching segments only", {
     3L
   })
 
-  invisible(frs_habitat_overlay(fake, "ws.h", "ws.k",
+  invisible(frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
                               species = "CO",
                               habitat_types = "spawning",
                               verbose = FALSE))
@@ -141,10 +149,10 @@ test_that("UPDATE SQL ORs in TRUE on matching segments only", {
 test_that("rejects malformed species codes (non-alphabetic)", {
   fake <- structure(list(), class = "DBIConnection")
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", species = "CO; DROP --"),
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", species = "CO; DROP --"),
     "alphabetic")
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", species = c("CO", "BAD CODE")),
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", species = c("CO", "BAD CODE")),
     "alphabetic")
 })
 
@@ -158,7 +166,7 @@ test_that("rejects habitat_types not in target table", {
     }
   })
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", species = "CO",
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", species = "CO",
                       habitat_types = c("spawning", "rearing"),
                       verbose = FALSE),
     "habitat_types not found")
@@ -176,7 +184,7 @@ test_that("custom by= produces matching join predicate", {
     captured <<- c(captured, sql); 0L
   })
 
-  frs_habitat_overlay(fake, "ws.h", "ws.k",
+  frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
                     species = "CO",
                     habitat_types = "spawning",
                     by = "id_segment",
@@ -205,7 +213,7 @@ test_that("NULL species pulls from table.species_code", {
     1L
   })
 
-  frs_habitat_overlay(fake, "ws.h", "ws.k",
+  frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
                     habitat_types = "spawning",
                     verbose = FALSE)
 
@@ -219,9 +227,9 @@ test_that("malicious identifiers are rejected by validator", {
   expect_error(
     frs_habitat_overlay(fake, "ws.h; DROP TABLE x; --", "ws.k"))
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", by = "bad-name"))
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", by = "bad-name"))
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k", habitat_types = "spawn'; DROP --"))
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h", habitat_types = "spawn'; DROP --"))
 })
 
 # -- Integration: real DB, small fixture --------------------------------------
@@ -266,8 +274,8 @@ test_that("integration: known segment flips FALSE -> TRUE on a fixture", {
        (100, 30.0, FALSE, FALSE)")
 
   invisible(frs_habitat_overlay(conn,
-    table = "working.test_known_h",
-    known = "working.test_known_k",
+    to = "working.test_known_h",
+    from = "working.test_known_k",
     species = "CO",
     habitat_types = c("spawning", "rearing"),
     verbose = FALSE))
@@ -315,8 +323,8 @@ test_that("integration: already-TRUE rows are not re-touched (additive-only)", {
   # `<sp>/<hab>: <n> segments flipped`. Use direct dbExecute to read
   # the matching count.
   invisible(frs_habitat_overlay(conn,
-    table = "working.test_known_h3",
-    known = "working.test_known_k3",
+    to = "working.test_known_h3",
+    from = "working.test_known_k3",
     species = "CO", habitat_types = "spawning",
     verbose = FALSE))
 
@@ -355,12 +363,14 @@ test_that("integration: idempotent on second call", {
   DBI::dbExecute(conn,
     "INSERT INTO working.test_known_k2 VALUES (100, 10.0, TRUE)")
 
-  invisible(frs_habitat_overlay(conn, "working.test_known_h2",
-    "working.test_known_k2", species = "CO",
-    habitat_types = "spawning", verbose = FALSE))
-  invisible(frs_habitat_overlay(conn, "working.test_known_h2",
-    "working.test_known_k2", species = "CO",
-    habitat_types = "spawning", verbose = FALSE))
+  invisible(frs_habitat_overlay(conn,
+    from = "working.test_known_k2",
+    to   = "working.test_known_h2",
+    species = "CO", habitat_types = "spawning", verbose = FALSE))
+  invisible(frs_habitat_overlay(conn,
+    from = "working.test_known_k2",
+    to   = "working.test_known_h2",
+    species = "CO", habitat_types = "spawning", verbose = FALSE))
 
   result <- DBI::dbGetQuery(conn,
     "SELECT spawning FROM working.test_known_h2")
@@ -375,7 +385,7 @@ test_that("long format: required columns checked up front", {
     mk_dbq("CO", TBL_DEFAULT,
            c("blue_line_key", "downstream_route_measure")))  # missing species_code, habitat_type, habitat_ind
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k",
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
                         species = "CO", format = "long"),
     "missing required columns")
 })
@@ -390,7 +400,7 @@ test_that("long format: SQL filters by species_code + habitat_type", {
   mockery::stub(frs_habitat_overlay, ".frs_db_execute", function(conn, sql) {
     captured[[length(captured) + 1L]] <<- sql; 0L
   })
-  invisible(frs_habitat_overlay(fake, "ws.h", "ws.k",
+  invisible(frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
     species = "CO", habitat_types = "spawning",
     format = "long", verbose = FALSE))
 
@@ -414,7 +424,7 @@ test_that("long format: custom long_value_col interpolated", {
   mockery::stub(frs_habitat_overlay, ".frs_db_execute", function(conn, sql) {
     captured <<- c(captured, sql); 0L
   })
-  frs_habitat_overlay(fake, "ws.h", "ws.k",
+  frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
     species = "CO", habitat_types = "spawning",
     format = "long", long_value_col = "is_known", verbose = FALSE)
 
@@ -425,7 +435,7 @@ test_that("long format: custom long_value_col interpolated", {
 test_that("long format: malicious long_value_col rejected by validator", {
   fake <- structure(list(), class = "DBIConnection")
   expect_error(
-    frs_habitat_overlay(fake, "ws.h", "ws.k",
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
                         format = "long", long_value_col = "bad'; DROP --"))
 })
 
@@ -462,8 +472,8 @@ test_that("integration (long): text 'TRUE' indicator flips segment", {
        (100, 20.0, 'CO', 'spawning', 'FALSE')")
 
   invisible(frs_habitat_overlay(conn,
-    table = "working.test_known_long_h",
-    known = "working.test_known_long_k",
+    to = "working.test_known_long_h",
+    from = "working.test_known_long_k",
     species = "CO", habitat_types = "spawning",
     format = "long", verbose = FALSE))
 
@@ -507,12 +517,144 @@ test_that("integration (long): boolean-typed indicator works", {
        (100, 20.0, 'CO', 'spawning', FALSE)")
 
   invisible(frs_habitat_overlay(conn,
-    table = "working.test_known_long_bool_h",
-    known = "working.test_known_long_bool_k",
+    to = "working.test_known_long_bool_h",
+    from = "working.test_known_long_bool_k",
     species = "CO", habitat_types = "spawning",
     format = "long", verbose = FALSE))
 
   result <- DBI::dbGetQuery(conn,
     "SELECT id_segment, spawning FROM working.test_known_long_bool_h ORDER BY id_segment")
   expect_equal(result$spawning, c(TRUE, FALSE))
+})
+
+# -- Bridge: range-containment 3-way join -------------------------------------
+
+test_that("bridge requires schema-qualified name", {
+  fake <- structure(list(), class = "DBIConnection")
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery",
+    mk_dbq("CO", TBL_DEFAULT,
+           c("blue_line_key", "downstream_route_measure", "spawning_co")))
+  expect_error(
+    frs_habitat_overlay(fake, from = "ws.k", to = "ws.h",
+                        bridge = "no_schema", species = "CO"),
+    "schema-qualified")
+})
+
+test_that("bridge: missing required columns errors clearly", {
+  fake <- structure(list(), class = "DBIConnection")
+  # Helper that returns different cols depending on which info_schema query
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery", function(conn, sql) {
+    if (grepl("DISTINCT species_code", sql)) {
+      data.frame(species_code = "CO")
+    } else if (grepl("table_name = 'h'", sql)) {
+      data.frame(column_name = TBL_DEFAULT)
+    } else if (grepl("table_name = 'k'", sql)) {
+      data.frame(column_name = c("blue_line_key", "downstream_route_measure",
+                                  "spawning_co"))
+    } else {
+      data.frame(column_name = c("id_segment"))  # bridge missing range cols
+    }
+  })
+  expect_error(
+    frs_habitat_overlay(fake,
+                        from = "ws.k", to = "ws.h", bridge = "ws.s",
+                        species = "CO"),
+    "bridge table.*missing required columns")
+})
+
+test_that("bridge: SQL emits 3-way range-containment join", {
+  fake <- structure(list(), class = "DBIConnection")
+  captured <- character(0)
+  mockery::stub(frs_habitat_overlay, "DBI::dbGetQuery", function(conn, sql) {
+    if (grepl("DISTINCT species_code", sql)) {
+      data.frame(species_code = "CO")
+    } else if (grepl("table_name = 'h'", sql)) {
+      data.frame(column_name = TBL_DEFAULT)
+    } else if (grepl("table_name = 'k'", sql)) {
+      data.frame(column_name = c("blue_line_key", "downstream_route_measure",
+                                  "spawning_co"))
+    } else {
+      data.frame(column_name = c("id_segment", "blue_line_key",
+                                  "downstream_route_measure",
+                                  "upstream_route_measure"))
+    }
+  })
+  mockery::stub(frs_habitat_overlay, ".frs_db_execute", function(conn, sql) {
+    captured <<- c(captured, sql); 0L
+  })
+
+  frs_habitat_overlay(fake,
+    from = "ws.k", to = "ws.h", bridge = "ws.s",
+    species = "CO", habitat_types = "spawning", verbose = FALSE)
+
+  expect_length(captured, 1)
+  sql <- captured[[1]]
+  expect_match(sql, "FROM ws\\.s AS s, ws\\.k AS k")
+  expect_match(sql, "h\\.id_segment = s\\.id_segment")
+  expect_match(sql, "s\\.blue_line_key = k\\.blue_line_key")
+  expect_match(sql, "s\\.downstream_route_measure >= k\\.downstream_route_measure")
+  expect_match(sql, "s\\.upstream_route_measure   <= k\\.upstream_route_measure")
+})
+
+test_that("integration (bridge): range-containment flips contained segments", {
+  skip_if_not(.frs_db_available(), "DB not available")
+  conn <- frs_db_conn()
+  on.exit({
+    .frs_test_drop(conn, "working.test_bridge_to")
+    .frs_test_drop(conn, "working.test_bridge_from")
+    .frs_test_drop(conn, "working.test_bridge_streams")
+    DBI::dbDisconnect(conn)
+  })
+
+  # Target: streams_habitat-style, keyed by id_segment only
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_bridge_to (
+       id_segment integer, species_code text,
+       spawning boolean, rearing boolean,
+       lake_rearing boolean, wetland_rearing boolean)")
+  # Three segments on BLK 100: drm 0-50, 50-100, 100-200
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_bridge_to VALUES
+       (1, 'CO', FALSE, FALSE, FALSE, FALSE),
+       (2, 'CO', FALSE, FALSE, FALSE, FALSE),
+       (3, 'CO', FALSE, FALSE, FALSE, FALSE)")
+
+  # Bridge: streams network with id_segment + ranges
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_bridge_streams (
+       id_segment integer, blue_line_key bigint,
+       downstream_route_measure double precision,
+       upstream_route_measure double precision)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_bridge_streams VALUES
+       (1, 100, 0.0, 50.0),
+       (2, 100, 50.0, 100.0),
+       (3, 100, 100.0, 200.0)")
+
+  # From: long-format, says CO spawning over drm [40, 110]
+  # — should include segment 2 (50-100) only;
+  #   segment 1 starts at 0 (< 40) so urm 50 > drm 40 means it's
+  #   PARTIALLY before — fails containment (drm 0 < 40), so excluded;
+  #   segment 3 ends at 200 > 110, also fails containment.
+  DBI::dbExecute(conn,
+    "CREATE TABLE working.test_bridge_from (
+       blue_line_key bigint,
+       downstream_route_measure double precision,
+       upstream_route_measure double precision,
+       species_code text, habitat_type text, habitat_ind text)")
+  DBI::dbExecute(conn,
+    "INSERT INTO working.test_bridge_from VALUES
+       (100, 40.0, 110.0, 'CO', 'spawning', 'TRUE')")
+
+  invisible(frs_habitat_overlay(conn,
+    from   = "working.test_bridge_from",
+    to     = "working.test_bridge_to",
+    bridge = "working.test_bridge_streams",
+    species = "CO", habitat_types = "spawning",
+    format = "long", verbose = FALSE))
+
+  result <- DBI::dbGetQuery(conn,
+    "SELECT id_segment, spawning FROM working.test_bridge_to ORDER BY id_segment")
+  # Segment 2 (50-100) is the only one fully contained in [40, 110]
+  expect_equal(result$spawning, c(FALSE, TRUE, FALSE))
 })


### PR DESCRIPTION
## Summary

Pre-1.0 cleanup of `frs_habitat_overlay()` driven by review of v0.20.0. No deprecation alias.

### Param renames (breaking)

- `table` → `to` (matches fresh's destination convention)
- `known` → `from` (matches source convention; detaches from "known habitat" provenance — function is the abstract overlay mechanism)

### New `bridge = NULL` parameter

When supplied, switches to a 3-way range-containment join:

```sql
to.id_segment = bridge.id_segment
AND bridge.<by[1]> = from.<by[1]>
AND bridge.downstream_route_measure >= from.downstream_route_measure
AND bridge.upstream_route_measure   <= from.upstream_route_measure
```

Lets target tables keyed by `id_segment` (e.g. `fresh.streams_habitat`) overlay from sources keyed by `(blue_line_key, drm)` ranges. Range columns auto-stripped from `by` in bridge mode.

### `frs_habitat_classify(known = NULL)` dropped (also breaking)

Convenience hid configurability now that overlay has `format` + `bridge` knobs. Two-step pattern is explicit and readable.

### Reads as a sentence

```r
frs_habitat_overlay(conn,
  from   = "ws.user_habitat_classification",
  to     = "fresh.streams_habitat",
  bridge = "fresh.streams",
  format = "long")
```

"Overlay flags from X to Y via this bridge."

Domain-agnostic — bridge can be any segments table providing `id_segment` + range columns. Stream networks today; lake / wetland centerlines or cottonwood-pinned segmentations tomorrow.

### Test plan

- [x] **54 scoped tests** pass (was 43; +11 from bridge schema, SQL shape, range-containment integration)
- [x] Full suite via rtj harness: **816 PASS / 0 FAIL / 13m00s** on m4 (was 806)
- [x] `/code-check` signed off — 3 cosmetic findings fixed (range-cols doc note, stale test names + comment, directional malicious-identifier coverage)

### Documented limitation

Range column names hardcoded to FWA convention (`downstream_route_measure` / `upstream_route_measure`). Non-FWA schemas would need a follow-up parameterisation — noted in `@param bridge` docs.

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
