### PR TITLE
Add in_waterbody boolean predicate to rule grammar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.22.0
+Version: 0.23.0
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# fresh 0.23.0
+
+Add `in_waterbody` boolean predicate to the rule grammar ([#180](https://github.com/NewGraphEnvironment/fresh/issues/180)).
+
+The rule grammar in `parameters_habitat_rules.yaml` already had positive predicates for selecting segments inside polygon waterbodies (`waterbody_type: R/L/W`) but no symmetric way to restrict a rule to segments **outside** any waterbody. That left the stream-edge rule families silent on polygon membership, so a stream rule like `edge_types_explicit: [1000, 1100, 2000, 2300]` matched both true streams and the same-coded centerlines that thread through wetland/lake/river polygons — overlapping with the polygon rules on those segments and double-classifying.
+
+This release adds `in_waterbody: false | true` as the natural complement to `waterbody_type:`. Stream-edge rules can now express "this classification only applies outside polygon footprints," which is the semantic complement of the existing polygon rules. Together the two predicates partition the network into stream-edge classifications and polygon-classifications with no overlap.
+
+- **`in_waterbody: false`** → adds `s.waterbody_key IS NULL` to the rule's AND chain.
+- **`in_waterbody: true`** → adds `s.waterbody_key IS NOT NULL`.
+- **absent** → no constraint (pre-`in_waterbody` behaviour, backward compatible).
+- Composes with `waterbody_type: <letter>` — the positive predicate already implies `IS NOT NULL`, so the two together are redundant rather than contradictory.
+- Validation: non-logical / NA / length>1 values raise an error at `.frs_rule_to_sql()` time.
+- 5 new tests under `test-frs_params.R` (112 in that file, was 107). Full suite green.
+
+Coordinates with [link#69](https://github.com/NewGraphEnvironment/link/issues/69) — `lnk_rules_build()` will emit `in_waterbody: false` on stream-edge rule blocks once this lands.
+
+Relates to NewGraphEnvironment/sred-2025-2026#24
+
 # fresh 0.22.0
 
 `frs_habitat_overlay()` simplified — drop `format` and `long_value_col` parameters; accept only the canonical source-table shape ([#177](https://github.com/NewGraphEnvironment/fresh/issues/177)).

--- a/R/utils.R
+++ b/R/utils.R
@@ -187,7 +187,19 @@
 #'
 #' @param rule Named list with optional fields: `edge_types`,
 #'   `edge_types_explicit`, `waterbody_type`, `lake_ha_min`,
-#'   `thresholds`.
+#'   `in_waterbody`, `thresholds`.
+#'
+#'   `in_waterbody` is a logical that constrains the rule to segments
+#'   inside or outside any waterbody polygon — `FALSE` adds
+#'   `s.waterbody_key IS NULL` (the natural complement of the positive
+#'   `waterbody_type` predicates; lets a stream-edge rule express "this
+#'   classification only applies outside polygon footprints"); `TRUE`
+#'   adds `s.waterbody_key IS NOT NULL`. Absent means no constraint
+#'   (rule matches segments inside or outside polygons indifferently;
+#'   pre-`in_waterbody` behaviour). Composes cleanly with
+#'   `waterbody_type:` — the positive `waterbody_type` predicate already
+#'   implies `IS NOT NULL`, so the two together are redundant rather
+#'   than contradictory.
 #' @param csv_thresholds Named list with `gradient = c(min, max)`
 #'   and/or `channel_width = c(min, max)`. Either may be NULL.
 #' @return Character. A parenthesized SQL predicate.
@@ -229,6 +241,19 @@
     codes <- as.integer(rule[["edge_types_explicit"]])
     parts <- c(parts, sprintf("s.edge_type IN (%s)",
       paste(codes, collapse = ", ")))
+  }
+
+  if (!is.null(rule[["in_waterbody"]])) {
+    in_wb <- rule[["in_waterbody"]]
+    if (!is.logical(in_wb) || length(in_wb) != 1L || is.na(in_wb)) {
+      stop("rule[['in_waterbody']] must be a single TRUE or FALSE",
+           call. = FALSE)
+    }
+    parts <- c(parts, if (in_wb) {
+      "s.waterbody_key IS NOT NULL"
+    } else {
+      "s.waterbody_key IS NULL"
+    })
   }
 
   if (!is.null(rule[["waterbody_type"]])) {

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -354,6 +354,49 @@ test_that(".frs_rule_to_sql empty rule returns (TRUE)", {
   expect_equal(.frs_rule_to_sql(list()), "(TRUE)")
 })
 
+test_that(".frs_rule_to_sql in_waterbody=FALSE adds IS NULL constraint", {
+  rule <- list(edge_types_explicit = c(1000L, 1100L),
+               in_waterbody = FALSE)
+  sql <- .frs_rule_to_sql(rule)
+  expect_match(sql, "s\\.edge_type IN \\(1000, 1100\\)")
+  expect_match(sql, "s\\.waterbody_key IS NULL")
+  expect_false(grepl("IS NOT NULL", sql))
+})
+
+test_that(".frs_rule_to_sql in_waterbody=TRUE adds IS NOT NULL constraint", {
+  rule <- list(edge_types_explicit = c(1000L), in_waterbody = TRUE)
+  sql <- .frs_rule_to_sql(rule)
+  expect_match(sql, "s\\.waterbody_key IS NOT NULL")
+})
+
+test_that(".frs_rule_to_sql absent in_waterbody behaves as today", {
+  rule <- list(edge_types_explicit = c(1000L, 1100L))
+  sql <- .frs_rule_to_sql(rule)
+  expect_false(grepl("waterbody_key", sql))
+})
+
+test_that(".frs_rule_to_sql in_waterbody composes with waterbody_type", {
+  # waterbody_type already implies IS NOT NULL via the IN (...) join.
+  # in_waterbody = TRUE alongside is redundant but should produce a
+  # well-formed conjunction, not an error or silent drop.
+  rule <- list(waterbody_type = "R", in_waterbody = TRUE)
+  sql <- .frs_rule_to_sql(rule)
+  expect_match(sql, "fwa_rivers_poly")
+  expect_match(sql, "s\\.waterbody_key IS NOT NULL")
+})
+
+test_that(".frs_rule_to_sql in_waterbody rejects non-logical values", {
+  expect_error(
+    .frs_rule_to_sql(list(in_waterbody = "false")),
+    "in_waterbody.*TRUE or FALSE")
+  expect_error(
+    .frs_rule_to_sql(list(in_waterbody = NA)),
+    "in_waterbody.*TRUE or FALSE")
+  expect_error(
+    .frs_rule_to_sql(list(in_waterbody = c(TRUE, FALSE))),
+    "in_waterbody.*TRUE or FALSE")
+})
+
 test_that(".frs_rules_to_sql empty list returns FALSE", {
   expect_equal(.frs_rules_to_sql(list()), "FALSE")
   expect_equal(.frs_rules_to_sql(NULL), "FALSE")


### PR DESCRIPTION
## Summary

Add `in_waterbody` boolean predicate to the rule grammar in `parameters_habitat_rules.yaml` (read by `frs_habitat_classify()` via `.frs_rule_to_sql()`).

The grammar already had positive predicates for selecting segments **inside** polygon waterbodies (`waterbody_type: R/L/W`) but no symmetric way to restrict a rule to segments **outside** any waterbody. That left stream-edge rules silent on polygon membership — a stream rule like `edge_types_explicit: [1000, 1100, 2000, 2300]` matched both true streams and the same-coded centerlines that thread through wetland/lake/river polygons, overlapping with the polygon rules on those segments.

`in_waterbody: false | true` is the natural complement of `waterbody_type:`. Stream-edge rules can now express "this classification only applies outside polygon footprints," which is the semantic complement of the existing polygon rules. Together the two predicates partition the network into stream-edge classifications and polygon-classifications with no overlap.

## Changes

- `R/utils.R::.frs_rule_to_sql()` — adds the `in_waterbody` block between the `edge_types_explicit` block and the `waterbody_type` block (closest neighbour semantically). `false` → `s.waterbody_key IS NULL`; `true` → `s.waterbody_key IS NOT NULL`; absent → no constraint.
- `R/utils.R` docstring updated with the new optional field + semantics + composition note.
- `tests/testthat/test-frs_params.R` — 5 new tests under the rule evaluator section.
- `NEWS.md` — 0.23.0 entry.
- `DESCRIPTION` — version bump 0.22.0 → 0.23.0.

## Behaviour

```r
rule <- list(edge_types_explicit = c(1000L, 1100L, 2000L, 2300L),
             in_waterbody = FALSE)
fresh:::.frs_rule_to_sql(rule)
#> "(s.edge_type IN (1000, 1100, 2000, 2300) AND s.waterbody_key IS NULL)"

rule <- list(edge_types_explicit = c(1000L, 1100L, 2000L, 2300L))   # absent
fresh:::.frs_rule_to_sql(rule)
#> "(s.edge_type IN (1000, 1100, 2000, 2300))"                        # backward-compat
```

## Validation

Non-logical / NA / length>1 values raise an error at `.frs_rule_to_sql()` time:

```r
fresh:::.frs_rule_to_sql(list(in_waterbody = "false"))
#> Error: rule[['in_waterbody']] must be a single TRUE or FALSE
```

## Coordinates with

[link#69](https://github.com/NewGraphEnvironment/link/issues/69) — `lnk_rules_build()` will emit `in_waterbody: false` on stream-edge rule blocks once this lands.

## Test plan

- [x] 5 new tests under `test-frs_params.R` (in_waterbody=FALSE, =TRUE, absent, composes-with-waterbody_type, validation rejects non-logical) — all PASS
- [x] Full test suite green (no regressions on 700+ existing tests)
- [x] Spot-checked SQL output via `devtools::load_all()`: produces the expected `IS NULL` / `IS NOT NULL` clauses; absent case unchanged
- [x] Backward-compat: rules without `in_waterbody:` produce SQL identical to pre-change

Closes #180
Relates to NewGraphEnvironment/sred-2025-2026#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
