### PR TITLE
Register in_waterbody with rules-YAML validator (#180 hotfix)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.23.0
+Version: 0.23.1
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# fresh 0.23.1
+
+Hotfix on top of 0.23.0 — register `in_waterbody` with the rules-YAML validator so emitted rules pass loading.
+
+`.frs_load_rules()` validates each rule entry's keys against an allowlist of known predicates (`valid_predicates` in `R/frs_params.R`). 0.23.0 added the predicate at the SQL emission layer (`.frs_rule_to_sql()`) but missed adding it to the allowlist, so a rules YAML carrying `in_waterbody:` was rejected by `.frs_load_rules()` before SQL emission ever ran. This release adds `in_waterbody` to `valid_predicates`.
+
+- 1 new test: `.frs_load_rules` accepts a YAML with `in_waterbody: true|false` on edge-type and waterbody-type rules (113 PASS in `test-frs_params.R`, was 112).
+- No behaviour change beyond unblocking the predicate that 0.23.0 introduced.
+
 # fresh 0.23.0
 
 Add `in_waterbody` boolean predicate to the rule grammar ([#180](https://github.com/NewGraphEnvironment/fresh/issues/180)).

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -134,6 +134,7 @@ frs_params <- function(conn = NULL,
 
   valid_predicates <- c("edge_types", "edge_types_explicit",
                         "waterbody_type", "lake_ha_min", "wetland_ha_min",
+                        "in_waterbody",
                         "thresholds", "gradient", "channel_width",
                         "requires_connected", "connected_distance_max")
 

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -120,6 +120,19 @@ test_that(".frs_load_rules errors on unknown predicate", {
   expect_error(.frs_load_rules(tmp), "unknown predicates")
 })
 
+test_that(".frs_load_rules accepts in_waterbody predicate (fresh#180)", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  spawn:",
+    "    - edge_types_explicit: [1000, 1100]",
+    "      in_waterbody: false",
+    "    - waterbody_type: R",
+    "      in_waterbody: true"), tmp)
+  expect_no_error(.frs_load_rules(tmp))
+})
+
 test_that(".frs_load_rules errors on lake_ha_min without waterbody_type L", {
   tmp <- tempfile(fileext = ".yaml")
   on.exit(unlink(tmp))


### PR DESCRIPTION
## Summary

Hotfix on top of 0.23.0 (#181). The new `in_waterbody` predicate was added to the SQL emission layer (`.frs_rule_to_sql()` in `R/utils.R`) but not to the allowlist consulted by `.frs_load_rules()` during YAML validation. So a rules YAML carrying `in_waterbody:` was rejected before SQL emission ran.

This came up immediately when [link#69](https://github.com/NewGraphEnvironment/link/issues/69) generated its first rules.yaml with `in_waterbody: false`:

```
Error: rules YAML BT/spawn rule 1 has unknown predicates: in_waterbody.
Valid: edge_types, edge_types_explicit, waterbody_type, lake_ha_min,
wetland_ha_min, thresholds, gradient, channel_width, requires_connected,
connected_distance_max
```

## Change

`R/frs_params.R::.frs_load_rules()` — add `"in_waterbody"` to `valid_predicates`. One token added to the existing list. `.frs_validate_rule()` already accepts it via `setdiff(keys, valid_predicates)`; nothing else needs touching since the per-rule semantics are validated downstream in `.frs_rule_to_sql()`.

## Tests

- 1 new test in `tests/testthat/test-frs_params.R`: `.frs_load_rules` accepts `in_waterbody: true|false` on both edge-type and waterbody-type rule entries.
- `test-frs_params`: 113 PASS / 0 FAIL (was 112).
- Full suite still green (no regressions).

## Closes

#180 (the gap that 0.23.0 left open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
