### PR TITLE
Add area_only flag to decouple bucket-flag derivation from rear predicate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.23.1
+Version: 0.24.0
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# fresh 0.24.0
+
+Add `area_only: true` flag to rule grammar — decouples bucket-flag derivation from the main `rear` predicate ([#182](https://github.com/NewGraphEnvironment/fresh/issues/182)).
+
+Today, a `waterbody_type: L` or `W` rule placed in a species' `rear:` list does two things at once: triggers fresh to derive a `lake_rearing` / `wetland_rearing` predicate (the per-segment flag that drives `lake_rearing_ha` / `wetland_rearing_ha` area rollups), AND OR's into the main `rear` predicate (the per-segment `rearing` flag, which drives linear `rearing_km`). The two effects are coupled, so a user can't say "credit the polygon area but exclude polygon-mainlines from linear km."
+
+This release adds `area_only: true` on a rule. When set, fresh uses the rule's predicate to derive the corresponding bucket flag (lake_rearing or wetland_rearing) but **does not include** the rule in the OR-chain that builds the main `rear` predicate. Stream-edge rules (with `in_waterbody: false` from #180) decide what counts as linear; L/W rules with `area_only: true` decide what polygons contribute area without double-counting the polygon-mainline as linear.
+
+- **`area_only: true`** on a `waterbody_type: L|W` rule → rule contributes to `lake_rear` / `wetland_rear` predicate derivation only, excluded from main `rear` predicate.
+- **`area_only: false`** or absent → today's behaviour (rule contributes to both). Backward compatible.
+- Validator: requires `waterbody_type: L` or `W` (no bucket flag to drive on stream-edge rules or `waterbody_type: R`); rejects non-logical / NA / length>1 values.
+- 13 new tests across `test-frs_params.R` (validator) and `test-frs_habitat_predicates.R` (decoupling). 167 PASS in those files (was 154). Full suite green.
+
+Coordinates with [link#69 phase 2](https://github.com/NewGraphEnvironment/link/issues/69) — `lnk_rules_build()` will emit `area_only: true` on L/W polygon rule blocks driven by per-species `rear_lake_area_only` / `rear_wetland_area_only` columns in `dimensions.csv`. Combined with the polygon-rule `edge_types_explicit: [1000, 1100]` filter (mainlines only), this expresses the use-case-2 model: linear excludes polygon-mainlines, area still rolls up.
+
+Relates to NewGraphEnvironment/sred-2025-2026#24
+
 # fresh 0.23.1
 
 Hotfix on top of 0.23.0 — register `in_waterbody` with the rules-YAML validator so emitted rules pass loading.

--- a/R/frs_habitat_predicates.R
+++ b/R/frs_habitat_predicates.R
@@ -112,7 +112,14 @@ frs_habitat_predicates <- function(sp_params) {
     csv_thresholds_rear <- list(
       gradient = if (is.null(rear_g)) NULL else c(0, rear_g[2]),
       channel_width = params_sp$ranges$rear$channel_width)
-    rear_pred <- .frs_rules_to_sql(params_sp[["rules"]][["rear"]],
+    # Filter out rules flagged `area_only: true` — those rules drive
+    # lake_rearing / wetland_rearing bucket-flag derivation only and
+    # should not contribute to the main `rear` predicate. The bucket
+    # rule lookup below still finds them via .frs_find_waterbody_rule().
+    rear_rules_for_main <- Filter(
+      function(r) !isTRUE(r[["area_only"]]),
+      params_sp[["rules"]][["rear"]])
+    rear_pred <- .frs_rules_to_sql(rear_rules_for_main,
                                    csv_thresholds_rear)
   } else {
     rear_pred <- "FALSE"

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -134,7 +134,7 @@ frs_params <- function(conn = NULL,
 
   valid_predicates <- c("edge_types", "edge_types_explicit",
                         "waterbody_type", "lake_ha_min", "wetland_ha_min",
-                        "in_waterbody",
+                        "in_waterbody", "area_only",
                         "thresholds", "gradient", "channel_width",
                         "requires_connected", "connected_distance_max")
 
@@ -236,6 +236,28 @@ frs_params <- function(conn = NULL,
       stop(sprintf(
         "rules YAML %s/%s rule %d wetland_ha_min must be a numeric scalar",
         sp, habitat, idx), call. = FALSE)
+    }
+  }
+
+  if (!is.null(rule[["area_only"]])) {
+    ao <- rule[["area_only"]]
+    if (!is.logical(ao) || length(ao) != 1L || is.na(ao)) {
+      stop(sprintf(
+        "rules YAML %s/%s rule %d area_only must be a single TRUE or FALSE",
+        sp, habitat, idx), call. = FALSE)
+    }
+    # area_only is only meaningful on bucket-flag rules (waterbody_type: L
+    # or W). On any other rule it has no effect — flag it as a config
+    # error so the author notices.
+    if (isTRUE(ao)) {
+      wt <- rule[["waterbody_type"]]
+      if (is.null(wt) || !wt %in% c("L", "W")) {
+        stop(sprintf(
+          paste0("rules YAML %s/%s rule %d uses area_only: true ",
+                 "without waterbody_type: L or W (no bucket flag to ",
+                 "drive)"),
+          sp, habitat, idx), call. = FALSE)
+      }
     }
   }
 

--- a/tests/testthat/test-frs_habitat_predicates.R
+++ b/tests/testthat/test-frs_habitat_predicates.R
@@ -215,3 +215,46 @@ test_that("returns named list with exactly 4 character predicates", {
     expect_length(p, 1)
   }
 })
+
+# -- area_only decoupling (fresh#182) ----------------------------------------
+
+test_that("area_only=true filters L rule from rear predicate but keeps lake_rear", {
+  # Two-rule rear: a stream-edge rule (contributes to rear) + an L rule
+  # marked area_only (drives lake_rear bucket flag, excluded from rear).
+  sp <- sp_with_rules(rules = list(
+    rear = list(
+      list(edge_types_explicit = c(1000L, 1100L), in_waterbody = FALSE),
+      list(waterbody_type = "L", lake_ha_min = 10, area_only = TRUE)
+    )))
+  preds <- frs_habitat_predicates(sp)
+  # rear predicate references the stream-edge rule's IS NULL clause but
+  # NOT fwa_lakes_poly (the L rule is filtered out).
+  expect_match(preds$rear, "edge_type IN \\(1000, 1100\\)")
+  expect_match(preds$rear, "waterbody_key IS NULL")
+  expect_no_match(preds$rear, "fwa_lakes_poly")
+  # lake_rear is still derived from the L rule's presence (independent
+  # of the rear predicate's OR-chain).
+  expect_match(preds$lake_rear, "fwa_lakes_poly")
+})
+
+test_that("area_only=true filters W rule from rear but keeps wetland_rear", {
+  sp <- sp_with_rules(rules = list(
+    rear = list(
+      list(edge_types_explicit = c(1000L, 1100L), in_waterbody = FALSE),
+      list(waterbody_type = "W", wetland_ha_min = 1, area_only = TRUE)
+    )))
+  preds <- frs_habitat_predicates(sp)
+  expect_no_match(preds$rear, "fwa_wetlands_poly")
+  expect_match(preds$wetland_rear, "fwa_wetlands_poly")
+})
+
+test_that("area_only=false (or absent) does not filter — backward compat", {
+  sp <- sp_with_rules(rules = list(
+    rear = list(
+      list(waterbody_type = "L", lake_ha_min = 10)
+    )))
+  preds <- frs_habitat_predicates(sp)
+  # Without area_only, the L rule contributes to rear AND drives lake_rear.
+  expect_match(preds$rear, "fwa_lakes_poly")
+  expect_match(preds$lake_rear, "fwa_lakes_poly")
+})

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -133,6 +133,58 @@ test_that(".frs_load_rules accepts in_waterbody predicate (fresh#180)", {
   expect_no_error(.frs_load_rules(tmp))
 })
 
+test_that(".frs_load_rules accepts area_only on L/W rules (fresh#182)", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - waterbody_type: L",
+    "      area_only: true",
+    "    - waterbody_type: W",
+    "      area_only: true"), tmp)
+  expect_no_error(.frs_load_rules(tmp))
+})
+
+test_that(".frs_load_rules errors on area_only without waterbody_type L|W", {
+  # area_only on a stream-edge rule has no bucket flag to drive — config error.
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types_explicit: [1000]",
+    "      area_only: true"), tmp)
+  expect_error(.frs_load_rules(tmp),
+    "area_only.*without waterbody_type: L or W")
+})
+
+test_that(".frs_load_rules errors on area_only with waterbody_type R", {
+  # River polygon doesn't drive a bucket flag in the current grammar
+  # (no `river_rearing` flag) — area_only on R is meaningless.
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - waterbody_type: R",
+    "      area_only: true"), tmp)
+  expect_error(.frs_load_rules(tmp),
+    "area_only.*without waterbody_type: L or W")
+})
+
+test_that(".frs_load_rules errors on non-logical area_only", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - waterbody_type: L",
+    "      area_only: \"yes\""), tmp)
+  expect_error(.frs_load_rules(tmp),
+    "area_only must be a single TRUE or FALSE")
+})
+
 test_that(".frs_load_rules errors on lake_ha_min without waterbody_type L", {
   tmp <- tempfile(fileext = ".yaml")
   on.exit(unlink(tmp))


### PR DESCRIPTION
## Summary

Adds `area_only: true` flag to the rule grammar. Closes #182.

A `waterbody_type: L` or `W` rule placed in a species' `rear:` list today does two things at once: triggers fresh to derive a `lake_rearing` / `wetland_rearing` bucket-flag predicate (which drives `lake_rearing_ha` / `wetland_rearing_ha` area rollups) AND OR's into the main `rear` predicate (which drives linear `rearing_km`). The two effects are coupled, so a user can't say "credit the polygon area but exclude polygon-mainlines from linear."

`area_only: true` decouples them. The rule still drives bucket-flag derivation; it's filtered out of the OR-chain that builds the main rear predicate.

## Changes

- `R/frs_habitat_predicates.R` — filters rules with `area_only: TRUE` out of the rear-rule list before passing to `.frs_rules_to_sql()`. Bucket-rule lookup (`.frs_find_waterbody_rule()`) is unchanged — still finds the L/W rule and derives `lake_rear_pred` / `wetland_rear_pred` from it.
- `R/frs_params.R` — `area_only` added to `valid_predicates`. Validator: must be a single TRUE/FALSE; if TRUE, requires `waterbody_type: L` or `W` (no bucket flag to drive on stream-edge rules or `waterbody_type: R`).
- `NEWS.md` — 0.24.0 entry.
- `DESCRIPTION` — version bump 0.23.1 → 0.24.0.

## Behaviour (sanity-checked via `devtools::load_all`)

```r
sp$rules$rear <- list(
  list(edge_types_explicit = c(1000L, 1100L), in_waterbody = FALSE),
  list(waterbody_type = "L", lake_ha_min = 10, area_only = TRUE)
)
preds <- frs_habitat_predicates(sp)

preds$rear
#> "((s.edge_type IN (1000, 1100) AND s.waterbody_key IS NULL ...))"
#>   no fwa_lakes_poly clause — L rule excluded from rear

preds$lake_rear
#> "s.channel_width >= 1.5 AND ... s.waterbody_key IN (
#>    SELECT waterbody_key FROM whse_basemapping.fwa_lakes_poly
#>    WHERE area_ha >= 10)"
#>   bucket flag still derived from the L rule's lake_ha_min
```

## Tests

- 4 new in `test-frs_params.R` (validator): accepts area_only on L/W; errors on stream-edge rule; errors on `waterbody_type: R`; errors on non-logical value.
- 3 new in `test-frs_habitat_predicates.R` (decoupling): area_only=TRUE on L filters from rear keeps lake_rear; same shape for W; absent/FALSE behaves as today (backward compat).
- 167 PASS across those two files (was 154). Full suite green.

## Coordinates with

[link#69 phase 2](https://github.com/NewGraphEnvironment/link/issues/69) — `lnk_rules_build()` emits `area_only: true` on L/W polygon rules driven by per-species `rear_lake_area_only` / `rear_wetland_area_only` columns in `dimensions.csv`. Combined with the polygon-rule `edge_types_explicit: [1000, 1100]` filter (mainlines only), expresses the use-case-2 model: linear excludes polygon-mainlines, area still rolls up.

Closes #182
Relates to NewGraphEnvironment/sred-2025-2026#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
