### PR TITLE
Allow channel_width_min_bypass in rules YAML validator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.27.0
+Version: 0.27.1
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fresh 0.27.1
+
+Patch follow-up to 0.27.0. `.frs_load_rules` validator now accepts the `channel_width_min_bypass` predicate that link emits to drive `frs_order_child()` post-classify (link#96 wiring). Validates that the field is a named mapping with `stream_order` and `stream_order_parent_min` integer scalars. Without this patch, link's emitted rules.yaml fails fast at `frs_params()` with `unknown predicates: channel_width_min_bypass` before any classification runs.
+
 # fresh 0.27.0
 
 Closes [#158](https://github.com/NewGraphEnvironment/fresh/pull/193). New `frs_order_child()`: post-classification UPDATE that credits direct order-1 (or other) tributaries of order-N+ rivers with `<label> = TRUE`. Captures the bcfishpass rearing bypass currently hard-coded in `model/02_habitat_linear/sql/load_habitat_linear_<sp>.sql` for BT/CH/CO/ST/WCT — predicate `cw.channel_width >= rear_channel_width_min OR (s.stream_order_parent >= 5 AND s.stream_order = 1)`.

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -136,6 +136,7 @@ frs_params <- function(conn = NULL,
                         "waterbody_type", "lake_ha_min", "wetland_ha_min",
                         "in_waterbody", "area_only",
                         "thresholds", "gradient", "channel_width",
+                        "channel_width_min_bypass",
                         "requires_connected", "connected_distance_max")
 
   for (sp in names(raw)) {
@@ -327,6 +328,38 @@ frs_params <- function(conn = NULL,
         stop(sprintf(
           "rules YAML %s/%s rule %d %s must be a numeric vector of length 2 [min, max]",
           sp, habitat, idx, field), call. = FALSE)
+      }
+    }
+  }
+
+  # channel_width_min_bypass: passthrough field consumed by
+  # frs_order_child() after classification. Not used by the rule engine
+  # itself — only validated for shape so a malformed YAML fails fast
+  # before classify runs.
+  if (!is.null(rule[["channel_width_min_bypass"]])) {
+    bypass <- rule[["channel_width_min_bypass"]]
+    if (!is.list(bypass) || is.null(names(bypass))) {
+      stop(sprintf(
+        "rules YAML %s/%s rule %d channel_width_min_bypass must be a named mapping",
+        sp, habitat, idx), call. = FALSE)
+    }
+    bypass_keys <- c("stream_order", "stream_order_parent_min")
+    unknown_b <- setdiff(names(bypass), bypass_keys)
+    if (length(unknown_b) > 0) {
+      stop(sprintf(
+        "rules YAML %s/%s rule %d channel_width_min_bypass has unknown keys: %s. Valid: %s",
+        sp, habitat, idx,
+        paste(unknown_b, collapse = ", "),
+        paste(bypass_keys, collapse = ", ")), call. = FALSE)
+    }
+    for (k in bypass_keys) {
+      v <- bypass[[k]]
+      if (is.null(v)) next
+      if (!is.numeric(v) || length(v) != 1L || is.na(v) ||
+          v != as.integer(v) || v < 1L) {
+        stop(sprintf(
+          "rules YAML %s/%s rule %d channel_width_min_bypass$%s must be a positive integer scalar",
+          sp, habitat, idx, k), call. = FALSE)
       }
     }
   }

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -258,6 +258,82 @@ test_that(".frs_load_rules errors on non-character edge_types", {
 })
 
 
+# --- channel_width_min_bypass validation tests ---
+
+test_that(".frs_load_rules accepts valid channel_width_min_bypass", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        stream_order_parent_min: 5"), tmp)
+  expect_silent(rules <- .frs_load_rules(tmp))
+  bypass <- rules$BT$rear[[1]]$channel_width_min_bypass
+  expect_equal(bypass$stream_order, 1L)
+  expect_equal(bypass$stream_order_parent_min, 5L)
+})
+
+test_that(".frs_load_rules accepts custom stream_order_parent_min", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        stream_order_parent_min: 7"), tmp)
+  expect_silent(rules <- .frs_load_rules(tmp))
+  expect_equal(
+    rules$BT$rear[[1]]$channel_width_min_bypass$stream_order_parent_min, 7L)
+})
+
+test_that(".frs_load_rules errors on unknown channel_width_min_bypass keys", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        bogus_key: 42"), tmp)
+  expect_error(.frs_load_rules(tmp), "unknown keys.*bogus_key")
+})
+
+test_that(".frs_load_rules errors on non-integer channel_width_min_bypass values", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        stream_order_parent_min: 5.5"), tmp)
+  expect_error(.frs_load_rules(tmp), "must be a positive integer scalar")
+})
+
+test_that(".frs_load_rules errors on non-list channel_width_min_bypass", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass: yes"), tmp)
+  expect_error(.frs_load_rules(tmp), "must be a named mapping")
+})
+
+
 # --- spawn_connected validation tests ---
 
 test_that(".frs_load_rules accepts valid spawn_connected block", {


### PR DESCRIPTION
## Summary

`frs_order_child()` (shipped in 0.27.0) is called post-classify by link's pipeline, driven by a `channel_width_min_bypass` block on rear rules in the link-emitted `rules.yaml`. The validator did not list this predicate, so `frs_params()` failed with `unknown predicates: channel_width_min_bypass` before classification could run.

This patch adds `channel_width_min_bypass` to `valid_predicates` and validates its shape: must be a named mapping with `stream_order` and `stream_order_parent_min` as positive integer scalars (mirrors the post-classify call's signature).

Closes the schema gap so [NewGraphEnvironment/link#96](https://github.com/NewGraphEnvironment/link/issues/96) wiring runs end-to-end.

## Test plan

- [x] 5 new validator tests in `test-frs_params.R` (accepts default + custom `stream_order_parent_min`, errors on unknown bypass keys, non-integer values, non-list block)
- [x] All 5 new tests pass; the 1 pre-existing `test-frs_params.R:92` failure (CO bundled rules count drift) is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
