### PR TITLE
Fix frs_order_child SQL: drop nonexistent stream_order_max column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.27.1
+Version: 0.27.2
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# fresh 0.27.2
+
+Fix `frs_order_child()` SQL referencing nonexistent column `s.stream_order_max`. `fresh.streams` has `stream_order` and `stream_order_parent` from FWA but no `stream_order_max` — the 0.27.0 SQL failed at execution against any real database (only the SQL-shape unit tests passed, and they asserted the broken predicate). Drop the broken predicate; default both `child_order_min` and `child_order_max` to `1L` when neither is set, which matches bcfishpass's hardcoded `stream_order = 1` predicate exactly. Caller-passed bounds still apply unchanged.
+
+Adds a regression test that scans the emitted SQL across every parameter combination for `stream_order_max` and fails if it reappears.
+
 # fresh 0.27.1
 
 Patch follow-up to 0.27.0. `.frs_load_rules` validator now accepts the `channel_width_min_bypass` predicate that link emits to drive `frs_order_child()` post-classify (link#96 wiring). Validates that the field is a named mapping with `stream_order` and `stream_order_parent_min` integer scalars. Without this patch, link's emitted rules.yaml fails fast at `frs_params()` with `unknown predicates: channel_width_min_bypass` before any classification runs.

--- a/R/frs_order_child.R
+++ b/R/frs_order_child.R
@@ -27,19 +27,21 @@
 #'
 #' @section Direct-child semantics:
 #'
-#' A "direct child" of a large river is a segment whose order matches
-#' the highest order on its blue_line_key — i.e., it flows directly
-#' into the parent river, not as a sub-tributary inside a multi-order
-#' network:
+#' A "direct child" of a large river is a segment whose stream_order
+#' matches the caller's child-order filter (`child_order_min` /
+#' `child_order_max`) AND whose `stream_order_parent` (the order of
+#' the river it flows into) is `>= parent_order_min`:
 #'
 #' ```
-#' s.stream_order = s.stream_order_max  -- (on the same blue_line_key)
 #' s.stream_order_parent >= parent_order_min
+#' [AND s.stream_order >= child_order_min]
+#' [AND s.stream_order <= child_order_max]
 #' ```
 #'
-#' The `stream_order = stream_order_max` test implicitly captures
-#' "stop at order change" — once the segment's order would exceed
-#' `stream_order_max`, you're no longer on the direct-child reach.
+#' Default child filter is `stream_order = 1` (matches bcfishpass's
+#' hard-coded predicate exactly). Pass `child_order_min` / `child_order_max`
+#' to widen — e.g. `child_order_min = 1, child_order_max = 2` for
+#' order-1 and order-2 tributaries.
 #'
 #' @section Distance grain:
 #'
@@ -60,10 +62,9 @@
 #'   AND <habitat>.species_code = '<species>'
 #'   AND <habitat>.accessible = TRUE
 #'   AND <habitat>.<label> IS NOT TRUE
-#'   AND s.stream_order = s.stream_order_max
 #'   AND s.stream_order_parent >= <parent_order_min>
-#'   [AND s.stream_order >= <child_order_min>]
-#'   [AND s.stream_order <= <child_order_max>]
+#'   AND s.stream_order >= <child_order_min>   -- default 1 if both NULL
+#'   AND s.stream_order <= <child_order_max>   -- default 1 if both NULL
 #'   [AND s.downstream_route_measure <= <distance_max>]
 #' ```
 #'
@@ -84,11 +85,13 @@
 #'   direct-child segment to qualify. Default `5L` (matches
 #'   bcfishpass's hard-coded value).
 #' @param child_order_min Integer or `NULL`. If set, segment's
-#'   `stream_order` must be `>= child_order_min`. Default `NULL` (no
-#'   floor — any order accepted).
+#'   `stream_order` must be `>= child_order_min`. Default `NULL`. When
+#'   both `child_order_min` and `child_order_max` are `NULL`, both
+#'   default to `1L` (matches bcfishpass's `stream_order = 1` predicate).
 #' @param child_order_max Integer or `NULL`. If set, segment's
-#'   `stream_order` must be `<= child_order_max`. Default `NULL`
-#'   (capped only by `stream_order_max` per the direct-child filter).
+#'   `stream_order` must be `<= child_order_max`. Default `NULL`. When
+#'   both `child_order_min` and `child_order_max` are `NULL`, both
+#'   default to `1L` (matches bcfishpass's `stream_order = 1` predicate).
 #' @param distance_max Numeric or `NULL`. If set, segment's
 #'   `downstream_route_measure` must be `<= distance_max` (metres from
 #'   tributary mouth). Default `NULL` (whole tributary).
@@ -140,6 +143,14 @@ frs_order_child <- function(conn,
   sp_quoted <- .frs_quote_string(species)
   pom <- as.integer(parent_order_min)
 
+  # Default both child bounds to 1L when neither is set — matches
+  # bcfishpass's `stream_order = 1` predicate exactly. Caller can pass
+  # one or both to widen (e.g. orders 1-2) or narrow.
+  if (is.null(child_order_min) && is.null(child_order_max)) {
+    child_order_min <- 1L
+    child_order_max <- 1L
+  }
+
   child_min_clause <- if (!is.null(child_order_min)) {
     sprintf("AND s.stream_order >= %d", as.integer(child_order_min))
   } else ""
@@ -159,7 +170,6 @@ frs_order_child <- function(conn,
        AND h.species_code = %s
        AND h.accessible = TRUE
        AND h.%s IS NOT TRUE
-       AND s.stream_order = s.stream_order_max
        AND s.stream_order_parent >= %d
        %s %s %s",
     habitat, label,

--- a/man/frs_order_child.Rd
+++ b/man/frs_order_child.Rd
@@ -38,12 +38,14 @@ direct-child segment to qualify. Default \code{5L} (matches
 bcfishpass's hard-coded value).}
 
 \item{child_order_min}{Integer or \code{NULL}. If set, segment's
-\code{stream_order} must be \verb{>= child_order_min}. Default \code{NULL} (no
-floor — any order accepted).}
+\code{stream_order} must be \verb{>= child_order_min}. Default \code{NULL}. When
+both \code{child_order_min} and \code{child_order_max} are \code{NULL}, both
+default to \code{1L} (matches bcfishpass's \code{stream_order = 1} predicate).}
 
 \item{child_order_max}{Integer or \code{NULL}. If set, segment's
-\code{stream_order} must be \verb{<= child_order_max}. Default \code{NULL}
-(capped only by \code{stream_order_max} per the direct-child filter).}
+\code{stream_order} must be \verb{<= child_order_max}. Default \code{NULL}. When
+both \code{child_order_min} and \code{child_order_max} are \code{NULL}, both
+default to \code{1L} (matches bcfishpass's \code{stream_order = 1} predicate).}
 
 \item{distance_max}{Numeric or \code{NULL}. If set, segment's
 \code{downstream_route_measure} must be \verb{<= distance_max} (metres from
@@ -84,18 +86,20 @@ and \code{distance_max} without touching the rule grammar.
 \section{Direct-child semantics}{
 
 
-A "direct child" of a large river is a segment whose order matches
-the highest order on its blue_line_key — i.e., it flows directly
-into the parent river, not as a sub-tributary inside a multi-order
-network:
+A "direct child" of a large river is a segment whose stream_order
+matches the caller's child-order filter (\code{child_order_min} /
+\code{child_order_max}) AND whose \code{stream_order_parent} (the order of
+the river it flows into) is \verb{>= parent_order_min}:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{s.stream_order = s.stream_order_max  -- (on the same blue_line_key)
-s.stream_order_parent >= parent_order_min
+\if{html}{\out{<div class="sourceCode">}}\preformatted{s.stream_order_parent >= parent_order_min
+[AND s.stream_order >= child_order_min]
+[AND s.stream_order <= child_order_max]
 }\if{html}{\out{</div>}}
 
-The \code{stream_order = stream_order_max} test implicitly captures
-"stop at order change" — once the segment's order would exceed
-\code{stream_order_max}, you're no longer on the direct-child reach.
+Default child filter is \code{stream_order = 1} (matches bcfishpass's
+hard-coded predicate exactly). Pass \code{child_order_min} / \code{child_order_max}
+to widen — e.g. \verb{child_order_min = 1, child_order_max = 2} for
+order-1 and order-2 tributaries.
 }
 
 \section{Distance grain}{
@@ -119,10 +123,9 @@ WHERE <habitat>.id_segment = s.id_segment
   AND <habitat>.species_code = '<species>'
   AND <habitat>.accessible = TRUE
   AND <habitat>.<label> IS NOT TRUE
-  AND s.stream_order = s.stream_order_max
   AND s.stream_order_parent >= <parent_order_min>
-  [AND s.stream_order >= <child_order_min>]
-  [AND s.stream_order <= <child_order_max>]
+  AND s.stream_order >= <child_order_min>   -- default 1 if both NULL
+  AND s.stream_order <= <child_order_max>   -- default 1 if both NULL
   [AND s.downstream_route_measure <= <distance_max>]
 }\if{html}{\out{</div>}}
 

--- a/tests/testthat/test-frs_order_child.R
+++ b/tests/testthat/test-frs_order_child.R
@@ -48,13 +48,19 @@ test_that("frs_order_child default emits canonical bcfishpass-parity SQL", {
   expect_match(s, "h\\.accessible = TRUE")
   expect_match(s, "h\\.rearing IS NOT TRUE")
 
-  # Direct-child predicate
-  expect_match(s, "s\\.stream_order = s\\.stream_order_max")
+  # bcfp-parity defaults: child stream_order = 1 (both bounds default
+  # to 1L when caller passes neither — matches bcfp's hardcoded
+  # `stream_order = 1` predicate).
+  expect_match(s, "s\\.stream_order >= 1")
+  expect_match(s, "s\\.stream_order <= 1")
   expect_match(s, "s\\.stream_order_parent >= 5")
 
-  # Optional clauses NOT present at default
-  expect_no_match(s, "s\\.stream_order >= ")
-  expect_no_match(s, "s\\.stream_order <= ")
+  # No nonexistent column reference: stream_order_max is NOT a column
+  # on fresh.streams. The original 0.27.0 SQL referenced it and broke
+  # at execution.
+  expect_no_match(s, "stream_order_max")
+
+  # Distance clause not present at default
   expect_no_match(s, "downstream_route_measure")
 })
 
@@ -64,14 +70,34 @@ test_that("frs_order_child emits child_order_min/max bounds when set", {
 
   expect_match(s, "s\\.stream_order >= 2")
   expect_match(s, "s\\.stream_order <= 4")
-  # Direct-child predicate still present (orthogonal)
-  expect_match(s, "s\\.stream_order = s\\.stream_order_max")
+  # No nonexistent column reference
+  expect_no_match(s, "stream_order_max")
 })
 
 test_that("frs_order_child emits distance_max clause when set", {
   sql_log <- .run_order_child(distance_max = 300)
   s <- sql_log[1]
   expect_match(s, "s\\.downstream_route_measure <= 300")
+})
+
+test_that("frs_order_child SQL never references stream_order_max", {
+  # 0.27.0 docstring + SQL referenced s.stream_order_max which is not
+  # a column on fresh.streams (only stream_order, stream_order_parent
+  # exist). Execution failed at the first call site (link's HORS
+  # pre-flight). Defend against re-introducing the broken reference
+  # in any code path.
+  for (args in list(
+    list(),
+    list(child_order_min = 1L),
+    list(child_order_max = 3L),
+    list(child_order_min = 1L, child_order_max = 2L),
+    list(distance_max = 500),
+    list(parent_order_min = 7L),
+    list(label = "lake_rearing"))) {
+    sql <- do.call(.run_order_child, args)
+    expect_no_match(sql[1], "stream_order_max",
+      info = paste("args:", paste(names(args), collapse = ",")))
+  }
 })
 
 test_that("frs_order_child handles parent_order_min override", {


### PR DESCRIPTION
## Summary

Fix execution-time bug in `frs_order_child()` shipped in 0.27.0. The emitted SQL referenced `s.stream_order_max`, a column that does not exist on `fresh.streams` (FWA provides `stream_order` and `stream_order_parent`; nothing else in this family).

The 0.27.0 unit tests only checked SQL string shape and asserted the broken predicate verbatim, so the bug landed without a real-DB execution check. Surfaced by link's HORS pre-flight when running the wired-up bypass against an actual fwapg database — execution failed at:

```
ERROR:  column s.stream_order_max does not exist
LINE 8:        AND s.stream_order = s.stream_order_max
```

## Fix

- Drop `AND s.stream_order = s.stream_order_max` from the emitted SQL.
- When the caller passes neither `child_order_min` nor `child_order_max`, default both to `1L` — matches bcfishpass's hardcoded `stream_order = 1 AND stream_order_parent >= 5` predicate exactly.
- Caller-passed bounds still apply unchanged (e.g. `child_order_min = 1, child_order_max = 2` for orders 1+2).
- Update docstring to reflect the new defaults.
- Update SQL-shape tests that asserted the broken predicate verbatim.

## Regression defense

New test scans emitted SQL across every parameter combination (default, child bounds set, distance set, parent override, alt label) and fails if `stream_order_max` reappears anywhere.

## Test plan

- [x] 32 PASS in `test-frs_order_child.R` (was 25 before — 7 new + updates)
- [x] HORS pre-flight on m4 runs to completion against fwapg + tunnel bcfishpass — verified post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
