### PR TITLE
Allow distance_max in channel_width_min_bypass YAML block

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fresh
 Title: Freshwater Referenced Spatial Hydrology
-Version: 0.27.3
+Version: 0.27.4
 Authors@R: c(
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fresh 0.27.4
+
+Allow optional `distance_max` key inside `channel_width_min_bypass` block in rules YAML — link uses it to cap the bypass to the lower N metres of each direct-trib BLK (i.e. `frs_order_child(distance_max = N)`). Validator accepts a positive numeric scalar; rejects zero / negative / non-numeric values.
+
 # fresh 0.27.3
 
 Restore `stream_order_max` predicate in `frs_order_child()` — the previous patch (0.27.2) removed the `s.stream_order = s.stream_order_max` filter because the column doesn't exist on `fresh.streams`. That was the wrong fix: the predicate is load-bearing for direct-child semantics. Without it, multi-order BLKs like a named creek that grows from order-1 headwaters to order-3 mouth (e.g. Divan Creek, BLK 356353593 in HORS) get their order-1 headwater segments credited as direct trib mouths of large rivers — they are not.

--- a/R/frs_params.R
+++ b/R/frs_params.R
@@ -343,7 +343,7 @@ frs_params <- function(conn = NULL,
         "rules YAML %s/%s rule %d channel_width_min_bypass must be a named mapping",
         sp, habitat, idx), call. = FALSE)
     }
-    bypass_keys <- c("stream_order", "stream_order_parent_min")
+    bypass_keys <- c("stream_order", "stream_order_parent_min", "distance_max")
     unknown_b <- setdiff(names(bypass), bypass_keys)
     if (length(unknown_b) > 0) {
       stop(sprintf(
@@ -352,7 +352,8 @@ frs_params <- function(conn = NULL,
         paste(unknown_b, collapse = ", "),
         paste(bypass_keys, collapse = ", ")), call. = FALSE)
     }
-    for (k in bypass_keys) {
+    # stream_order / stream_order_parent_min must be positive integer scalars.
+    for (k in c("stream_order", "stream_order_parent_min")) {
       v <- bypass[[k]]
       if (is.null(v)) next
       if (!is.numeric(v) || length(v) != 1L || is.na(v) ||
@@ -360,6 +361,15 @@ frs_params <- function(conn = NULL,
         stop(sprintf(
           "rules YAML %s/%s rule %d channel_width_min_bypass$%s must be a positive integer scalar",
           sp, habitat, idx, k), call. = FALSE)
+      }
+    }
+    # distance_max is a positive numeric scalar (metres along route).
+    if (!is.null(bypass[["distance_max"]])) {
+      v <- bypass[["distance_max"]]
+      if (!is.numeric(v) || length(v) != 1L || is.na(v) || v <= 0) {
+        stop(sprintf(
+          "rules YAML %s/%s rule %d channel_width_min_bypass$distance_max must be a positive numeric scalar",
+          sp, habitat, idx), call. = FALSE)
       }
     }
   }

--- a/tests/testthat/test-frs_params.R
+++ b/tests/testthat/test-frs_params.R
@@ -333,6 +333,38 @@ test_that(".frs_load_rules errors on non-list channel_width_min_bypass", {
   expect_error(.frs_load_rules(tmp), "must be a named mapping")
 })
 
+test_that(".frs_load_rules accepts channel_width_min_bypass.distance_max", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        stream_order_parent_min: 5",
+    "        distance_max: 300"), tmp)
+  expect_silent(rules <- .frs_load_rules(tmp))
+  expect_equal(
+    rules$BT$rear[[1]]$channel_width_min_bypass$distance_max, 300)
+})
+
+test_that(".frs_load_rules errors on non-positive channel_width_min_bypass.distance_max", {
+  tmp <- tempfile(fileext = ".yaml")
+  on.exit(unlink(tmp))
+  writeLines(c(
+    "BT:",
+    "  rear:",
+    "    - edge_types:",
+    "        - stream",
+    "      channel_width_min_bypass:",
+    "        stream_order: 1",
+    "        stream_order_parent_min: 5",
+    "        distance_max: -100"), tmp)
+  expect_error(.frs_load_rules(tmp), "must be a positive numeric scalar")
+})
+
 
 # --- spawn_connected validation tests ---
 


### PR DESCRIPTION
## Summary

Validator now accepts an optional `distance_max` key inside `channel_width_min_bypass` alongside `stream_order` and `stream_order_parent_min`. Threading the value through to `frs_order_child(distance_max = N)` lets callers cap the bypass to the lower N metres of each direct-trib BLK.

Used by link's `lnk_pipeline_classify` when the dimensions.csv column `rear_stream_order_distance_max` is set per species.

## Test plan

- [x] 2 new validator tests in `test-frs_params.R` (accepts positive numeric, rejects negative)
- [x] All other validator tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
